### PR TITLE
feat: Video Preview on "Data Pemeriksaan" Page

### DIFF
--- a/Oculab/Modules/VideoRecord/Components/VideoInput.swift
+++ b/Oculab/Modules/VideoRecord/Components/VideoInput.swift
@@ -18,6 +18,9 @@ struct VideoInput: View {
     @Binding var showOnboardingGuidelines: Bool
     @Binding var didFinishOnboarding: Bool
     @Binding var selectedURL: URL?
+    
+    @State private var showFullScreenPlayer = false
+    @State private var showVideoErrorAlert = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Decimal.d8) {
@@ -52,7 +55,29 @@ struct VideoInput: View {
                         .cornerRadius(Decimal.d8)
 
                     AppButton(title: "Preview Video", leftIcon: "eye", colorType: .secondary, size: .small) {
-                        previewVideo()
+                        // Cek apakah file masih bisa diputar
+                        if let url = selectedURL, FileManager.default.fileExists(atPath: url.path) {
+                            showFullScreenPlayer = true
+                        } else {
+                            showVideoErrorAlert = true
+                        }
+                    }
+                }
+            }
+            // Alert untuk error handling
+            .alert(isPresented: $showVideoErrorAlert) {
+                Alert(
+                    title: Text("Gagal Memutar Video"),
+                    message: Text("Video tidak dapat diputar. Silakan rekam ulang sampel."),
+                    dismissButton: .default(Text("Kembali"))
+                )
+            }
+            
+            // Full-screen video preview overlay
+            .fullScreenCover(isPresented: $showFullScreenPlayer) {
+                if let url = selectedURL {
+                    FullScreenVideoPlayerView(videoURL: url) {
+                        showFullScreenPlayer = false
                     }
                 }
             }

--- a/Oculab/Modules/VideoRecord/View/FullScreenVideoPlayerView.swift
+++ b/Oculab/Modules/VideoRecord/View/FullScreenVideoPlayerView.swift
@@ -1,0 +1,38 @@
+//
+//  FullScreenVideoPlayerView.swift
+//  Oculab
+//
+//  Created by Rangga Yudhistira Brata on 24/05/25.
+//
+
+import SwiftUI
+import AVKit
+
+struct FullScreenVideoPlayerView: View {
+    let videoURL: URL
+    var onClose: () -> Void
+    
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VideoPlayer(player: AVPlayer(url: videoURL)) {
+                // Optional: Kosongkan untuk sembunyikan overlay bawaan
+            }
+            .onAppear {
+                let player = AVPlayer(url: videoURL)
+                player.play()
+            }
+            .edgesIgnoringSafeArea(.all)
+            
+            // Tombol "Close"
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .resizable()
+                    .frame(width: 32, height: 32)
+                    .padding()
+                    .foregroundColor(.white)
+                    .shadow(radius: 4)
+            }
+        }
+        .background(Color.black.edgesIgnoringSafeArea(.all))
+    }
+}


### PR DESCRIPTION
After the user records a video of the sample, they will be redirected to the “Data Pemeriksaan” page. On this page, the user can tap the “Preview Video” button to open a full-screen video preview. Referensi: [OCLB-205](https://oculab.atlassian.net/jira/software/projects/OCLB/boards/1?assignee=63fb887e0e0ddcdce18bd0f0&selectedIssue=OCLB-205)