### PR TITLE
fix(auth): resolve forget-PIN, FaceID, and stale UserDefaults issues

### DIFF
--- a/Oculab/Modules/Authentication/Presenter/AuthenticationPresenter.swift
+++ b/Oculab/Modules/Authentication/Presenter/AuthenticationPresenter.swift
@@ -430,37 +430,6 @@ extension AuthenticationPresenter {
         }
     }
     
-    func onPinCreation() {
-        var description: String = AppValue.empty
-        
-        if state == .create {
-            if isAccessPinChangeInProgress {
-                description = AppTextAuthCompPin.titleCreateChangePin
-            } else {
-                description = AppTextAuthCompPin.titleCreatePin
-            }
-        } else {
-            switch state {
-            case .create:
-                description = isAccessPinChangeInProgress ? AppTextAuthCompPin.titleCreateChangePin : AppTextAuthCompPin.titleCreatePin
-            case .revalidate:
-                if isAccessPinChangeInProgress {
-                    description = AppTextAuthCompPin.revalidateChangePinTitle
-                } else {
-                    description = AppTextAuthCompPin.revalidatePinTitle
-                }
-            case .authenticate:
-                description = AppTextAuthCompPin.titleAuthenticatePin
-            case .changePIN:
-                description = AppTextAuthCompPin.changePinTitle
-            case .forgetPin:
-                description = AppValue.empty
-            }
-        }
-        
-        descriptionPIN = description
-    }
-    
     var title: String {
         switch state {
         case .create:
@@ -541,20 +510,14 @@ extension AuthenticationPresenter {
             Logger.error("Failed to delete access PIN from backend: \(error)", category: .authentication)
             isError = true
             errorMessage = ErrorHandler.shared.handleError(error, context: .login)
+            return
         }
-        
-        // Clear all local user session data
+
         clearLoginState()
-        
-        // Reset authentication state
         resetAuthenticationState()
-        
-        // Set app state to unauthenticated to show login screen
         appStateManager?.setUnauthenticated()
-        
-        // Navigate to login
         Router.shared.popToRoot()
-        
+
         Logger.info("User successfully logged out via forget PIN", category: .authentication)
     }
     
@@ -582,6 +545,10 @@ extension AuthenticationPresenter {
         return isFaceIdEnabledFromUserDefaults && state == .authenticate && isFaceIdAvailable
     }
 
+    func hasStoredAccessPin() async -> Bool {
+        return await interactor.getUserLocalData()?.accessPin != nil
+    }
+
     @MainActor
     func authenticateWithFaceID() async {
         let context = LAContext()
@@ -603,18 +570,13 @@ extension AuthenticationPresenter {
         }
 
         do {
-            try await withCheckedThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 context.evaluatePolicy(
                     .deviceOwnerAuthenticationWithBiometrics,
                     localizedReason: AppTextAuthBiometric.activationPrompt
                 ) { success, authenticationError in
                     if success {
                         continuation.resume(returning: ())
-                        DispatchQueue.main.async {
-                            self.isPinAuthorized = true
-                            // State transition handled by AccountCheckerView onChange
-                            Router.shared.popToRoot()
-                        }
                     } else {
                         continuation.resume(throwing: authenticationError ?? NSError(
                             domain: "AuthenticationError",
@@ -623,17 +585,18 @@ extension AuthenticationPresenter {
                     }
                 }
             }
+            isPinAuthorized = true
+            // State transition handled by AccountCheckerView onChange
+            Router.shared.popToRoot()
         } catch {
-            DispatchQueue.main.async {
-                self.isError = true
-                self.description = AppTextAuthProfile.descFailedFaceID(error: error.localizedDescription)
-            }
+            isError = true
+            description = AppTextAuthProfile.descFailedFaceID(error: error.localizedDescription)
         }
     }
 
     func updateFaceIdPreference(_ isEnabled: Bool) {
         isFaceIdEnabledFromUserDefaults = isEnabled
-        UserDefaults.standard.set(isEnabled, forKey: "isFaceIdEnabled")
+        UserDefaults.standard.set(isEnabled, forKey: UserDefaultType.isFaceIdEnabled.rawValue)
     }
     
     @MainActor

--- a/Oculab/Modules/Authentication/View/UserAccessPinView.swift
+++ b/Oculab/Modules/Authentication/View/UserAccessPinView.swift
@@ -133,11 +133,12 @@ struct UserAccessPinView: View {
                     securityPresenter.isError = false
                     Task {
                         securityPresenter.checkFaceIDAvailability()
-                        
-                        // Automatically trigger Face ID if enabled and this is authentication mode
-                        if securityPresenter.isFaceIdEnabled(state: state) {
-                            await securityPresenter.authenticateWithFaceID()
-                        }
+
+                        // Skip FaceID auto-prompt when there's no stored PIN to fall back to.
+                        guard securityPresenter.isFaceIdEnabled(state: state),
+                              await securityPresenter.hasStoredAccessPin()
+                        else { return }
+                        await securityPresenter.authenticateWithFaceID()
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Quick-win fixes from an audit of `Modules/Authentication`. No behavior changes for the happy path; corrects edge cases that could cause state corruption or stale auto-prompts.

- **`handleForgetPin`**: `return` after a backend failure so the user isn't logged out when the server didn't actually delete the PIN. Previously, local logout ran unconditionally — diverging local/server state.
- **`authenticateWithFaceID`**: state mutation (`isPinAuthorized`, `popToRoot`) moved out of the `LAContext` callback to after `try await withCheckedThrowingContinuation`. Removed the now-redundant `DispatchQueue.main.async` wrappers (the method is already `@MainActor`).
- **`updateFaceIdPreference`**: replaced hardcoded `"isFaceIdEnabled"` with `UserDefaultType.isFaceIdEnabled.rawValue` so the read/write sites can't drift.
- **`UserAccessPinView.onAppear`**: skip FaceID auto-prompt when no stored PIN exists. New `hasStoredAccessPin()` helper on the presenter.
- **Dead code removal**: `onPinCreation()` (uncalled; logic now lives in `setDescriptionPIN()`).

## Test plan
- [ ] Login → revalidate PIN with FaceID enabled: prompt appears, success unlocks home
- [ ] Login → revalidate PIN with FaceID enabled but no stored PIN: no auto-prompt
- [ ] Forget-PIN with backend reachable: user logged out, returned to login
- [ ] Forget-PIN with backend offline: error shown, user remains logged in
- [ ] Toggle FaceID off in profile, kill app, relaunch: FaceID stays off (key persistence works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)