### PR TITLE
fix(auth): move access/refresh tokens from UserDefaults to Keychain

### DIFF
--- a/Oculab/Common/Services/Storage/KeychainHelper.swift
+++ b/Oculab/Common/Services/Storage/KeychainHelper.swift
@@ -1,0 +1,105 @@
+//
+//  KeychainHelper.swift
+//  Oculab
+//
+
+import Foundation
+import Security
+
+enum KeychainKey: String {
+    case accessToken
+    case refreshToken
+}
+
+enum KeychainHelper {
+    private static let service = Bundle.main.bundleIdentifier ?? "com.Oculab.Oculab"
+
+    @discardableResult
+    static func set(_ value: String, for key: KeychainKey) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return true }
+
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery.merge(attributes) { _, new in new }
+            return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+        }
+
+        return false
+    }
+
+    static func string(for key: KeychainKey) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8)
+        else { return nil }
+        return value
+    }
+
+    @discardableResult
+    static func remove(_ key: KeychainKey) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key.rawValue,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    static func removeAll() {
+        for key in [KeychainKey.accessToken, .refreshToken] {
+            remove(key)
+        }
+    }
+
+    /// Run once at app launch:
+    /// 1. On a fresh install (no UserDefaults flag), wipe any Keychain items
+    ///    that survived an uninstall — they'd otherwise re-authenticate the
+    ///    new install as the previous user.
+    /// 2. Migrate tokens previously stored in UserDefaults into Keychain.
+    static func bootstrap() {
+        let defaults = UserDefaults.standard
+        let installedKey = "keychain.bootstrap.installed"
+
+        if !defaults.bool(forKey: installedKey) {
+            removeAll()
+            defaults.set(true, forKey: installedKey)
+        }
+
+        // Legacy keys are the raw enum values used before this migration.
+        let legacyAccess = "accessToken"
+        let legacyRefresh = "refreshToken"
+
+        if let access = defaults.string(forKey: legacyAccess), !access.isEmpty {
+            set(access, for: .accessToken)
+            defaults.removeObject(forKey: legacyAccess)
+        }
+        if let refresh = defaults.string(forKey: legacyRefresh), !refresh.isEmpty {
+            set(refresh, for: .refreshToken)
+            defaults.removeObject(forKey: legacyRefresh)
+        }
+    }
+}

--- a/Oculab/Entities/Enum/UserDefaultType.swift
+++ b/Oculab/Entities/Enum/UserDefaultType.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 enum UserDefaultType: String, CaseIterable {
-    case accessToken
-    case refreshToken
     case isUserLoggedIn
     case userId
     case accessPin

--- a/Oculab/Modules/Authentication/Interactor/AuthenticationInteractor.swift
+++ b/Oculab/Modules/Authentication/Interactor/AuthenticationInteractor.swift
@@ -81,9 +81,9 @@ class AuthenticationInteractor: ObservableObject {
             body: UserBody(email: email, password: password)
         )
 
-        // Store user data
-        UserDefaults.standard.set(response.data.accessToken, forKey: UserDefaultType.accessToken.rawValue)
-        UserDefaults.standard.set(response.data.refreshToken, forKey: UserDefaultType.refreshToken.rawValue)
+        // Store credentials in Keychain; non-secret state in UserDefaults.
+        KeychainHelper.set(response.data.accessToken, for: .accessToken)
+        KeychainHelper.set(response.data.refreshToken, for: .refreshToken)
         UserDefaults.standard.set(true, forKey: UserDefaultType.isUserLoggedIn.rawValue)
         UserDefaults.standard.set(true, forKey: UserDefaultType.firstTimeLogin.rawValue)
         UserDefaults.standard.set(response.data.userId, forKey: UserDefaultType.userId.rawValue)
@@ -185,7 +185,7 @@ class AuthenticationInteractor: ObservableObject {
     }
     
     func editNewPIN(newAccessPin: String, previousAccessPin: String) async throws -> UserUpdateAccessPinResponse {
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
         
@@ -215,7 +215,7 @@ class AuthenticationInteractor: ObservableObject {
     }
     
     func createAccessPin(accessPin: String) async throws -> CreateAccessPinResponse {
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
         
@@ -238,7 +238,7 @@ class AuthenticationInteractor: ObservableObject {
     }
 
     func deleteAccessPin() async throws -> DeleteAccessPinResponse {
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
         

--- a/Oculab/Modules/Authentication/Interactor/ProfileInteractor.swift
+++ b/Oculab/Modules/Authentication/Interactor/ProfileInteractor.swift
@@ -34,7 +34,7 @@ class ProfileInteractor: ProfileInteractorProtocol {
     private let apiAuthenticationService = API.BE + "/user"
 
     func editNewPassword(newPassword: String, previousPassword: String) async throws -> UserUpdatePasswordResponse {
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
         

--- a/Oculab/Modules/Authentication/Presenter/AuthenticationPresenter.swift
+++ b/Oculab/Modules/Authentication/Presenter/AuthenticationPresenter.swift
@@ -710,8 +710,7 @@ extension AuthenticationPresenter {
         UserDefaults.standard.removeObject(forKey: UserDefaultType.isUserLoggedIn.rawValue)
         UserDefaults.standard.removeObject(forKey: UserDefaultType.firstTimeLogin.rawValue)
         UserDefaults.standard.removeObject(forKey: UserDefaultType.userId.rawValue)
-        UserDefaults.standard.removeObject(forKey: UserDefaultType.accessToken.rawValue)
-        UserDefaults.standard.removeObject(forKey: UserDefaultType.refreshToken.rawValue)
+        KeychainHelper.removeAll()
     }
     
     func isUserLoggedIn() -> Bool {

--- a/Oculab/Modules/TaskAssignment/Interactor/InputPatientInteractor.swift
+++ b/Oculab/Modules/TaskAssignment/Interactor/InputPatientInteractor.swift
@@ -30,7 +30,7 @@ class InputPatientInteractor {
             )
         }
         
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
 

--- a/Oculab/Modules/UserManagement/Interactor/AccountInteractor.swift
+++ b/Oculab/Modules/UserManagement/Interactor/AccountInteractor.swift
@@ -35,7 +35,7 @@ class AccountInteractor: ObservableObject {
             )
         }
 
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
 
@@ -71,7 +71,7 @@ class AccountInteractor: ObservableObject {
             )
         }
         
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
 
@@ -93,7 +93,7 @@ class AccountInteractor: ObservableObject {
     }
     
     func editAccount(userId: String, name: String? = nil, role: RolesType? = nil) async throws -> EditAccountResponse {
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
         
@@ -137,7 +137,7 @@ class AccountInteractor: ObservableObject {
     }
     
     func deleteAccount(userId: String) async throws -> DeleteAccountResponse {
-        guard let token = UserDefaults.standard.string(forKey: UserDefaultType.accessToken.rawValue) else {
+        guard let token = KeychainHelper.string(for: .accessToken) else {
             throw URLError(.userAuthenticationRequired)
         }
 

--- a/Oculab/OculabApp.swift
+++ b/Oculab/OculabApp.swift
@@ -16,12 +16,14 @@ struct OculabApp: App {
     @StateObject private var authPresenter = DependencyInjection.shared.createAuthPresenter()
 
     init() {
+        KeychainHelper.bootstrap()
+
         do {
             self.container = try ModelContainer(for: User.self)
         } catch {
             fatalError("Failed to initialize SwiftData ModelContainer: \(error.localizedDescription)")
         }
-        
+
         DependencyInjection.shared.initializer(modelContext: container.mainContext)
     }
 


### PR DESCRIPTION
## Summary

`accessToken` and `refreshToken` were stored in `UserDefaults` — included in iCloud/iTunes backups in cleartext and readable via filesystem inspection. This PR moves them to Keychain.

- Adds `KeychainHelper` (Generic Password class, `AccessibleAfterFirstUnlockThisDeviceOnly`).
- Migrates every read/write site: `AuthenticationInteractor`, `ProfileInteractor`, `AccountInteractor`, `InputPatientInteractor`, `AuthenticationPresenter.clearLoginState`.
- `KeychainHelper.bootstrap()` runs once from `OculabApp.init`:
  - Fresh-install detection wipes Keychain so a reinstall doesn't inherit the previous user's tokens (a known iOS Keychain pitfall).
  - Existing logged-in users have their `UserDefaults` tokens copied into Keychain transparently — no forced re-login.
- Drops `accessToken` / `refreshToken` cases from `UserDefaultType`.

`userId` stays in `UserDefaults` — it's an identifier, not a credential.

## Test plan
- [ ] Existing user upgrades from previous build → still logged in, can hit any authenticated endpoint
- [ ] Logout clears tokens (`KeychainHelper.string(for: .accessToken)` returns nil afterward)
- [ ] Login → kill app → relaunch: tokens persist
- [ ] Uninstall → reinstall: clean state (login screen)
- [ ] Backup-and-restore (or new device, same Apple ID): tokens NOT restored (Keychain is `ThisDeviceOnly`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)