### PR TITLE
fix(auth): surface PIN error on screen and drop dead init Task

### DIFF
--- a/Oculab/Modules/Authentication/Presenter/AuthenticationPresenter.swift
+++ b/Oculab/Modules/Authentication/Presenter/AuthenticationPresenter.swift
@@ -267,15 +267,15 @@ extension AuthenticationPresenter {
         // For PIN change flow, we should check against oldAccessPin, not the stored PIN
         if isAccessPinChangeInProgress {
             if oldAccessPin != inputPin {
-                isError = true
                 description = AppTextAuthCompPin.invalidPinText
+                isError = true
                 return false
             }
         } else {
             // Normal authentication - check against stored PIN
             if await interactor.getUserLocalData()?.accessPin != inputPin {
-                isError = true
                 description = AppTextAuthCompPin.invalidPinText
+                isError = true
                 return false
             }
         }
@@ -320,8 +320,8 @@ extension AuthenticationPresenter {
                     Router.shared.popToRoot()
                 }
             } else {
-                isError = true
                 inputPin = AppValue.empty
+                isError = true
                 // Error description is already set in revalidatePinMatched()
             }
 
@@ -769,8 +769,14 @@ extension AuthenticationPresenter {
     }
     
     private func updateUIForErrorState() {
-        if !isError {
+        if isError {
+            // Surface the error message on the PIN screen, which reads `descriptionPIN`.
+            if !description.isEmpty {
+                descriptionPIN = description
+            }
+        } else {
             description = AppValue.empty
+            setDescriptionPIN()
         }
         textColor = isError ? AppColors.red500 : AppColors.slate900
         pinColor = isError ? AppColors.red500 : AppColors.purple500

--- a/Oculab/Modules/Authentication/Presenter/ProfilePresenter.swift
+++ b/Oculab/Modules/Authentication/Presenter/ProfilePresenter.swift
@@ -73,9 +73,6 @@ class ProfilePresenter: ObservableObject {
         self.formValidation = FormValidationViewModel()
         self.interactor = interactor
         self.authInteractor = authInteractor
-        Task {
-            await self.getUser()
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Two small auth fixes from the audit.

**#8 PIN error message wasn't showing**
The PIN screen displays `descriptionPIN`, but `isValidPin()` and `revalidatePinMatched()` only wrote the error to `description`. Result: when a user entered the wrong PIN, the field went red but no message appeared. Two changes:

1. Set `description` *before* `isError` in the failure paths so the `isError` didSet sees the message.
2. In `updateUIForErrorState()`, mirror `description` into `descriptionPIN` while in error state; restore the normal title via `setDescriptionPIN()` when the error clears.

**#9 ProfilePresenter init race**
Dropped `Task { await self.getUser() }` from `ProfilePresenter.init`. Nobody actually reads `profilePresenter.user` — `ProfileView` uses `authPresenter.user` — so the init-time async work was both racy and dead. If a future consumer needs it, they should drive it from a `.task {}` modifier.

## Test plan
- [ ] Authenticate PIN screen: enter wrong PIN → field turns red AND "PIN tidak sesuai" (or equivalent) appears
- [ ] Wrong PIN, then correct PIN: error message clears, title reverts
- [ ] Create PIN flow: enter mismatching second PIN → mismatch message visible
- [ ] Profile tab opens without flicker / without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)