### PR TITLE
fix: examination follow-up (stale state, cleanup warning, SCANTY count)

### DIFF
--- a/Oculab/Modules/Examination/Presenter/AnalysisResultPresenter.swift
+++ b/Oculab/Modules/Examination/Presenter/AnalysisResultPresenter.swift
@@ -25,7 +25,15 @@ class AnalysisResultPresenter: ObservableObject {
     @Published var isLoading = false
 
     // MARK: - UI State Properties
-    @Published var selectedTBGrade: String = AppValue.empty
+    @Published var selectedTBGrade: String = AppValue.empty {
+        didSet {
+            // Drop SCANTY-specific count when staff switches to a different grade,
+            // so submitExpertResult doesn't ship a stale value alongside e.g. PLUS3.
+            if selectedTBGrade != GradingType.SCANTY.rawValue {
+                numOfBTA = AppValue.empty
+            }
+        }
+    }
     @Published var numOfBTA: String = AppValue.empty
     @Published var inspectorNotes: String = AppValue.empty
     @Published private var currentStep: Int = 3

--- a/Oculab/Modules/Examination/Presenter/AppTextExamination.swift
+++ b/Oculab/Modules/Examination/Presenter/AppTextExamination.swift
@@ -26,6 +26,7 @@ extension AppText {
         static let titleResultInterpretation = "examination.title_result_interpretation".localized
         static let buttonStartAnalysis = "examination.button_start_analysis".localized
         static let buttonSubmitting = "examination.button_submitting".localized
+        static let tempFileCleanupWarning = "examination.temp_file_cleanup_warning".localized
 
         enum ProgressView {
             static let loadingAnimationName = "loadingPaperplane"

--- a/Oculab/Modules/Examination/Presenter/ExamDataPresenter.swift
+++ b/Oculab/Modules/Examination/Presenter/ExamDataPresenter.swift
@@ -39,6 +39,7 @@ class ExamDataPresenter: ObservableObject {
     )
     @Published var examinations: [AdminExaminationData] = []
     @Published var submissionError: String?
+    @Published var cleanupWarning: String?
 
     // MARK: - Initialization
     init(interactor: ExamInteractor) {
@@ -75,18 +76,21 @@ extension ExamDataPresenter {
         recordVideo = videoPresenter.previewURL
     }
 
-    private func deleteTemporaryFile(at url: URL) {
+    @discardableResult
+    private func deleteTemporaryFile(at url: URL) -> Bool {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: url.path) else {
             Logger.warning("Temporary file does not exist at path: \(url.path)", category: .examination)
-            return
+            return true
         }
-        
+
         do {
             try fileManager.removeItem(at: url)
             Logger.info("Successfully deleted temporary video file at: \(url.path)", category: .examination)
+            return true
         } catch {
             Logger.error("Error deleting temporary video file: \(error.localizedDescription)", category: .examination)
+            return false
         }
     }
 }
@@ -129,7 +133,9 @@ extension ExamDataPresenter {
 
             recordVideo = nil
             videoPresenter.previewURL = nil
-            deleteTemporaryFile(at: fileURL)
+            if !deleteTemporaryFile(at: fileURL) {
+                cleanupWarning = AppTextExam.tempFileCleanupWarning
+            }
 
             return true
         } catch {
@@ -137,6 +143,34 @@ extension ExamDataPresenter {
             submissionError = ErrorHandler.shared.handleError(error, context: .examination)
             return false
         }
+    }
+}
+
+// MARK: - State Reset
+extension ExamDataPresenter {
+    @MainActor
+    func resetState() {
+        isLoading = false
+        recordVideo = nil
+        examDetailData = .init(
+            examinationId: AppValue.empty,
+            pic: AppValue.empty,
+            slideId: AppValue.empty,
+            examinationGoal: AppValue.empty,
+            type: AppValue.empty,
+            dpjp: AppValue.empty
+        )
+        patientDetailData = .init(
+            patientId: AppValue.empty,
+            name: AppValue.empty,
+            nik: AppValue.empty,
+            dob: AppValue.empty,
+            sex: AppValue.empty,
+            bpjs: AppValue.empty
+        )
+        examinations = []
+        submissionError = nil
+        cleanupWarning = nil
     }
 }
 

--- a/Oculab/Modules/Examination/View/ExamDetailAdminView.swift
+++ b/Oculab/Modules/Examination/View/ExamDetailAdminView.swift
@@ -139,9 +139,15 @@ struct ExamDetailAdminView: View {
             }
             .onAppear {
                 Task {
+                    presenter.resetState()
+                    resultPresenter.resetState()
                     await presenter.fetchData(examId: examId, patientId: patientId, userRole: .ADMIN)
                     await resultPresenter.fetchData(examinationId: examId)
                 }
+            }
+            .onDisappear {
+                presenter.resetState()
+                resultPresenter.resetState()
             }
         }.navigationBarBackButtonHidden(true)
     }

--- a/Oculab/Modules/Examination/View/SavedResultView.swift
+++ b/Oculab/Modules/Examination/View/SavedResultView.swift
@@ -143,9 +143,15 @@ struct SavedResultView: View {
             }
             .onAppear {
                 Task {
+                    presenter.resetState()
+                    resultPresenter.resetState()
                     await presenter.fetchData(examId: examId, patientId: patientId, userRole: .LAB)
                     await resultPresenter.fetchData(examinationId: examId)
                 }
+            }
+            .onDisappear {
+                presenter.resetState()
+                resultPresenter.resetState()
             }
         }.navigationBarBackButtonHidden(true)
     }

--- a/Oculab/en.lproj/Localizable.strings
+++ b/Oculab/en.lproj/Localizable.strings
@@ -404,6 +404,7 @@
 "examination.title_result_interpretation" = "Interpretation Results";
 "examination.button_start_analysis" = "Start Analysis";
 "examination.button_submitting" = "Submitting...";
+"examination.temp_file_cleanup_warning" = "Examination submitted, but the temporary recording could not be removed from the device.";
 
 // Progress View
 "examination.progress.analyzing_title" = "Interpreting data";

--- a/Oculab/id.lproj/Localizable.strings
+++ b/Oculab/id.lproj/Localizable.strings
@@ -420,6 +420,7 @@
 "examination.title_result_interpretation" = "Hasil Interpretasi";
 "examination.button_start_analysis" = "Mulai Analisis";
 "examination.button_submitting" = "Mengirimkan...";
+"examination.temp_file_cleanup_warning" = "Pemeriksaan terkirim, tapi rekaman sementara tidak dapat dihapus dari perangkat.";
 
 // Progress View
 "examination.progress.analyzing_title" = "Menginterpretasikan data";


### PR DESCRIPTION
## Summary

Stacked on top of #182. Picks up the three remaining Examination findings that #182 deferred.

- **#10 — `numOfBTA` carries across grade switches.** Added a `didSet` on `selectedTBGrade` that clears `numOfBTA` whenever the grade isn't `SCANTY`. Without this, `submitExpertResult` was shipping `bacteriaTotalCount` from a previous SCANTY selection alongside e.g. `PLUS3`. Cleaner data and matches the conditional UI (the BTA field only renders for SCANTY anyway).
- **#5 — Dual-`@StateObject` stale data in `SavedResultView` / `ExamDetailAdminView`.** Added `ExamDataPresenter.resetState()` and call both presenters' `resetState()` in `.onAppear` (before fetch) and `.onDisappear` on both views. Avoids the heavier DI rework and reliably clears patient/exam fields between navigations.
- **#8 — `deleteTemporaryFile` failures swallowed.** Promoted the helper to return `Bool` and added `cleanupWarning: String?` to `ExamDataPresenter`. On submit success but cleanup failure, the warning is set with a localized string (en + id). The view layer can surface it whenever it's ready.

## Stacking

Targets `fix/examination-audit` (PR #182). Will rebase onto `develop` once #182 lands. Each fix is independent and can be cherry-picked if #182's review changes anything.

## Test plan

- [ ] Pick SCANTY → enter count → switch to PLUS3 → confirm `numOfBTA` cleared (and submit body doesn't ship the stale value)
- [ ] Open SavedResultView for exam A → back → open SavedResultView for exam B → confirm exam A's data isn't briefly visible
- [ ] Same flow for ExamDetailAdminView
- [ ] Force a failure in `FileManager.removeItem` (e.g., delete file out from under us mid-submit) and confirm `cleanupWarning` is populated while submission still reports success

🤖 Generated with [Claude Code](https://claude.com/claude-code)