### PR TITLE
fix(videorecord): harden capture lifecycle, observers, and recording state

### DIFF
--- a/Oculab/Modules/VideoRecord/Components/CameraAndVideoComponents.swift
+++ b/Oculab/Modules/VideoRecord/Components/CameraAndVideoComponents.swift
@@ -100,15 +100,19 @@ class CameraPreviewCoordinator: NSObject {
     
     @MainActor
     @objc func handleTap(_ gesture: UITapGestureRecognizer) {
-        let tapPoint = gesture.location(in: gesture.view)
-        guard let view = gesture.view else { return }
-        
+        guard let view = gesture.view,
+              view.bounds.width > 0,
+              view.bounds.height > 0 else { return }
+
+        let tapPoint = gesture.location(in: view)
+        guard view.bounds.contains(tapPoint) else { return }
+
         // Convert tap point to camera coordinate system
         let devicePoint = CGPoint(
             x: tapPoint.y / view.bounds.height,
             y: 1.0 - (tapPoint.x / view.bounds.width)
         )
-        
+
         focusCamera(at: devicePoint)
     }
     

--- a/Oculab/Modules/VideoRecord/Components/VideoPlayerManager.swift
+++ b/Oculab/Modules/VideoRecord/Components/VideoPlayerManager.swift
@@ -25,6 +25,7 @@ class VideoPlayerManager: ObservableObject {
     // MARK: - Private Properties
     private var cancellables = Set<AnyCancellable>()
     private let videoURL: URL
+    private var timeObserverToken: Any?
     
     // MARK: - Initialization
     init(videoURL: URL) {
@@ -35,14 +36,13 @@ class VideoPlayerManager: ObservableObject {
     func setupPlayer() {
         // Validate video file exists
         guard FileManager.default.fileExists(atPath: videoURL.path) else {
-            Logger.error("Video file does not exist at path: \(videoURL.path)", category: .videoRecord)
+            Logger.error("Video file does not exist", category: .videoRecord)
             hasError = true
             isLoading = false
             return
         }
-        
-        Logger.info("Setting up video player for URL: \(videoURL.path)", category: .videoRecord)
-        Logger.info("File size: \(getFileSize(videoURL))", category: .videoRecord)
+
+        Logger.info("Setting up video player (size: \(getFileSize(videoURL)))", category: .videoRecord)
         
         player = AVPlayer(url: videoURL)
         
@@ -97,6 +97,10 @@ class VideoPlayerManager: ObservableObject {
     }
     
     func cleanup() {
+        if let token = timeObserverToken {
+            player?.removeTimeObserver(token)
+            timeObserverToken = nil
+        }
         player?.pause()
         player = nil
         cancellables.removeAll()
@@ -106,11 +110,21 @@ class VideoPlayerManager: ObservableObject {
     private func loadVideoAsset() {
         let asset = AVAsset(url: videoURL)
         Task {
+            // Verify the file is still readable before loading metadata
+            guard FileManager.default.isReadableFile(atPath: videoURL.path) else {
+                await MainActor.run {
+                    self.hasError = true
+                    self.isLoading = false
+                }
+                Logger.error("Video file is not readable", category: .videoRecord)
+                return
+            }
+
             do {
                 let duration = try await asset.load(.duration)
                 let isPlayable = try await asset.load(.isPlayable)
                 let hasVideoTracks = try await asset.loadTracks(withMediaType: .video).count > 0
-                
+
                 await MainActor.run {
                     self.duration = CMTimeGetSeconds(duration)
                     if isPlayable && hasVideoTracks {
@@ -165,14 +179,14 @@ class VideoPlayerManager: ObservableObject {
             .store(in: &cancellables)
         
         // Monitor current time
-        player.addPeriodicTimeObserver(
+        timeObserverToken = player.addPeriodicTimeObserver(
             forInterval: CMTime(seconds: 0.1, preferredTimescale: 600),
             queue: .main
         ) { [weak self] time in
             guard let self = self, !self.isDragging else { return }
             let newTime = CMTimeGetSeconds(time)
             self.currentTime = newTime
-            
+
             // Check if video has reached the end
             if self.duration > 0 && abs(newTime - self.duration) < 0.1 {
                 self.hasReachedEnd = true
@@ -194,12 +208,13 @@ class VideoPlayerManager: ObservableObject {
     
     private func replayVideo() {
         guard let player = player else { return }
-        
+
         let startTime = CMTime.zero
         player.seek(to: startTime) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.hasReachedEnd = false
-                self?.currentTime = 0
+                guard let self = self, let player = self.player else { return }
+                self.hasReachedEnd = false
+                self.currentTime = 0
                 player.play()
                 Logger.info("Video replaying from start", category: .videoRecord)
             }

--- a/Oculab/Modules/VideoRecord/Components/VideoPreview.swift
+++ b/Oculab/Modules/VideoRecord/Components/VideoPreview.swift
@@ -168,17 +168,23 @@ struct VideoPreview: View {
         // Clean up current video
         player?.pause()
         player = nil
-        
-        // Delete temporary file
-        if let url = videoRecordPresenter.previewURL {
-            deleteTemporaryFile(at: url)
+
+        let urlToRemove = videoRecordPresenter.previewURL
+
+        Task { @MainActor in
+            // Stop the capture session before deleting the file to release the writer handle
+            await videoRecordPresenter.stopCameraSession()
+
+            if let url = urlToRemove {
+                videoRecordPresenter.deleteTemporaryFile(at: url)
+            }
+
+            // Reset presenter state
+            videoRecordPresenter.previewURL = nil
+            videoRecordPresenter.stitchedImage = nil
+
+            Logger.info("Video retake initiated", category: .videoRecord)
         }
-        
-        // Reset presenter state
-        videoRecordPresenter.previewURL = nil
-        videoRecordPresenter.stitchedImage = nil
-        
-        Logger.info("Video retake initiated", category: .videoRecord)
     }
     
     private func shareVideo() {
@@ -197,21 +203,13 @@ struct VideoPreview: View {
     
     private func deleteVideo() {
         guard let url = videoRecordPresenter.previewURL else { return }
-        
-        deleteTemporaryFile(at: url)
+
+        videoRecordPresenter.deleteTemporaryFile(at: url)
         videoRecordPresenter.previewURL = nil
         videoRecordPresenter.navigateBack()
     }
-    
-    private func deleteTemporaryFile(at url: URL) {
-        do {
-            try FileManager.default.removeItem(at: url)
-            Logger.info("Temporary video file deleted: \(url.lastPathComponent)", category: .videoRecord)
-        } catch {
-            Logger.error("Failed to delete temporary file: \(error.localizedDescription)", category: .videoRecord)
-        }
-    }
-    
+
+
     private func formatTime(_ time: Double) -> String {
         let minutes = Int(time) / 60
         let seconds = Int(time) % 60

--- a/Oculab/Modules/VideoRecord/Presenter/VideoRecordPresenter.swift
+++ b/Oculab/Modules/VideoRecord/Presenter/VideoRecordPresenter.swift
@@ -57,7 +57,10 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     private let maxZoomFactor: CGFloat = 4.9
     private var recordingTimer: Timer?
     private var recordingStartTime: Date?
-    private let frameProcessingQueue = DispatchQueue(label: "frameProcessingQueue", qos: .userInteractive)
+    private let frameProcessingQueue = DispatchQueue(
+        label: "com.oculab.videorecord.frameProcessing",
+        qos: .userInteractive
+    )
 
     // MARK: - Constants
     let preRecordingInstructions: [String] = AppTextVideoRecordInstruction.preRecordingInstructions
@@ -95,27 +98,22 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     private func setUp() async {
         isLoading = true
         defer { isLoading = false }
-        
+
+        session.beginConfiguration()
+
         do {
-            session.beginConfiguration()
-            
-            // Remove existing inputs and outputs
             removeExistingInputsAndOutputs()
-            
-            // Setup camera inputs (audio disabled to reduce file size)
-            try await setupInputs()
-            
-            // Setup outputs
+            try setupInputs()
             setupOutputs()
-            
             session.commitConfiguration()
-            
-            await startCameraSession()
-            
         } catch {
-            print("Setup error: \(error.localizedDescription)")
+            session.commitConfiguration()
+            Logger.error("Camera setup failed: \(error.localizedDescription)", category: .videoRecord)
             errorMessage = "Failed to setup camera: \(error.localizedDescription)"
+            return
         }
+
+        await startCameraSession()
     }
     
     private func removeExistingInputsAndOutputs() {
@@ -242,33 +240,32 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     @MainActor
     func startRecording() {
         guard !isRecording else { return }
-        
-        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(AppTextVideoRecordView.videoFileDateAndExtension())
-        
-        // Configure recording quality
-        configureRecordingQuality()
-        
-        output.startRecording(to: tempURL, recordingDelegate: self)
+
+        // Mark recording state before issuing I/O to prevent double-tap races
         isRecording = true
         recordingStartTime = Date()
-//        showRecordingTitle = true
-        
+
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(AppTextVideoRecordView.videoFileDateAndExtension())
+
+        configureRecordingQuality()
+
+        output.startRecording(to: tempURL, recordingDelegate: self)
         startRecordingTimer()
-        
-        Logger.info("Recording started at: \(tempURL.lastPathComponent)", category: .videoRecord)
+
+        Logger.info("Recording started", category: .videoRecord)
     }
-    
+
+
     @MainActor
     func stopRecording() {
         guard isRecording else { return }
-        
+
         output.stopRecording()
         isRecording = false
-//        showRecordingTitle = false
-        
+
         stopRecordingTimer()
-        
+
         Logger.info("Recording stopped", category: .videoRecord)
     }
     
@@ -297,7 +294,7 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     }
 
     // MARK: - AVCaptureFileOutputRecordingDelegate
-    func fileOutput(
+    nonisolated func fileOutput(
         _ output: AVCaptureFileOutput,
         didFinishRecordingTo outputFileURL: URL,
         from connections: [AVCaptureConnection],
@@ -306,30 +303,33 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
         Task { @MainActor in
             if let error = error {
                 Logger.error("Recording error: \(error.localizedDescription)", category: .videoRecord)
-                errorMessage = error.localizedDescription
-                previewURL = nil
+                self.errorMessage = error.localizedDescription
+                self.previewURL = nil
+                self.deleteTemporaryFile(at: outputFileURL)
                 return
             }
 
-            Logger.info("Recording finished: \(outputFileURL.lastPathComponent)", category: .videoRecord)
-            previewURL = outputFileURL
-            await stopCameraSession()
+            Logger.info("Recording finished successfully", category: .videoRecord)
+            self.previewURL = outputFileURL
+            await self.stopCameraSession()
         }
     }
-    
+
     // MARK: - AVCaptureVideoDataOutputSampleBufferDelegate
-    func captureOutput(
+    nonisolated func captureOutput(
         _ output: AVCaptureOutput,
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
-        guard isRecording,
-              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
-        
-        // Process frame for stitching if needed
-        processFrameForStitching(pixelBuffer: pixelBuffer)
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self = self, self.isRecording else { return }
+            self.processFrameForStitching(pixelBuffer: pixelBuffer)
+        }
     }
-    
+
+    @MainActor
     private func processFrameForStitching(pixelBuffer: CVPixelBuffer) {
         // Check if enough time has passed since last stitch
         let currentTime = Date()
@@ -337,20 +337,17 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
            currentTime.timeIntervalSince(lastTime) < stitchInterval {
             return
         }
-        
+
         lastStitchTime = currentTime
-        
+
         // Convert pixel buffer to UIImage
         let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
         let context = CIContext()
-        
+
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return }
         let uiImage = UIImage(cgImage: cgImage)
-        
-        // Perform stitching on main thread
-        Task { @MainActor in
-            stitchNewFrame(uiImage)
-        }
+
+        stitchNewFrame(uiImage)
     }
     
     // MARK: - UI State Management
@@ -417,10 +414,6 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     }
 
     // MARK: - Navigation
-//    func navigateToVideo() {
-//        Router.shared.navigateTo(.videoRecord(slideId: ))
-//    }
-
     func navigateBack() {
         Router.shared.navigateBack()
     }
@@ -492,9 +485,12 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     // MARK: - Camera Controls
     @MainActor
     func updateZoom(factor: CGFloat) {
-        guard let device = session.inputs.first as? AVCaptureDeviceInput else { return }
-        let cameraDevice = device.device
+        guard let videoInput = session.inputs
+            .compactMap({ $0 as? AVCaptureDeviceInput })
+            .first(where: { $0.device.hasMediaType(.video) })
+        else { return }
 
+        let cameraDevice = videoInput.device
         let clampedFactor = min(max(factor, minZoomFactor), maxZoomFactor)
 
         do {
@@ -505,6 +501,21 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
         } catch {
             Logger.error("Error setting zoom: \(error.localizedDescription)", category: .videoRecord)
             errorMessage = "Failed to adjust zoom"
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    func deleteTemporaryFile(at url: URL) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: url.path) else { return true }
+        do {
+            try fileManager.removeItem(at: url)
+            Logger.info("Temporary recording removed", category: .videoRecord)
+            return true
+        } catch {
+            Logger.error("Failed to remove temporary recording: \(error.localizedDescription)", category: .videoRecord)
+            return false
         }
     }
     
@@ -520,23 +531,27 @@ class VideoRecordPresenter: NSObject, ObservableObject, AVCapturePhotoCaptureDel
     // MARK: - Cleanup
     @MainActor
     func cleanup() async {
+        // Stop recording cleanly if in progress so the timer is invalidated
+        // and no orphan capture finishes after the view is gone.
+        if isRecording {
+            output.stopRecording()
+        }
         stopRecordingTimer()
         await stopCameraSession()
-        
+
         // Reset all state
         isRecording = false
         showPlayerView = false
-//        showRecordingTitle = false
         stitchedImage = nil
         progressImage = nil
         errorMessage = nil
         recordingDuration = 0.0
         zoomFactor = 1.0
-        
+
         // Clear URLs but don't reset previewURL if it exists
         recordedURLs.removeAll()
         resetSpecimenTitle()
-        
+
         Logger.info("VideoRecordPresenter cleaned up successfully", category: .videoRecord)
     }
     


### PR DESCRIPTION
## Summary

Audit-driven fixes across `VideoRecordPresenter`, `VideoPlayerManager`, `VideoPreview`, and `CameraAndVideoComponents` to close concurrency, lifecycle, and resource leaks in the video capture flow.

### Critical
- **Delegate isolation** (`VideoRecordPresenter.swift:300/321`): `AVCaptureFileOutputRecordingDelegate` and `AVCaptureVideoDataOutputSampleBufferDelegate` methods are now `nonisolated`; mutations are routed through `MainActor.run` / `Task @MainActor`. Resolves a pre-existing isolation warning and a real background-thread @Published mutation.
- **Periodic time observer leak** (`VideoPlayerManager.swift`): the token returned by `addPeriodicTimeObserver` is now stored and removed in `cleanup()`.
- **Mid-`beginConfiguration` bailout** (`setUp`): on input/output setup failure we now still call `commitConfiguration()` to leave the session in a valid state.

### High
- **Double-tap race** (`startRecording`): `isRecording` is set before `output.startRecording` so the second tap can no longer schedule a duplicate.
- **Timer leak on dismissal** (`cleanup`): if the view dismisses mid-record we now stop the capture and invalidate the recording timer.
- **Delegate failure path**: the orphan temp file is now deleted when the recording completes with an error.
- **Retake during running session** (`VideoPreview.retakeVideo`): we stop the capture session before removing the temporary file so the writer handle is released first.
- **`replayVideo` seek completion** now guards `self` and re-fetches the player from the strong reference.
- **`updateZoom` device guard**: pick the input that actually has video media instead of `inputs.first`.
- **Tap-to-focus geometry**: validate view bounds and tap location before computing the device point.

### Medium / Low
- `VideoPlayerManager.loadVideoAsset` now checks `FileManager.isReadableFile` before metadata load.
- Frame processing dispatch queue label is now `com.oculab.videorecord.frameProcessing` (reverse-DNS, easier to spot in Instruments).
- Removed dead commented-out `navigateToVideo` block and `showRecordingTitle` toggles.
- Scrubbed full temp-file paths from recording logs (kept size-only for player setup).

## Test plan
- [ ] Launch a recording, double-tap the record button rapidly — verify only one recording starts.
- [ ] Start a recording then background/dismiss the view — verify timer stops and no orphan file remains.
- [ ] Force a recording error (e.g., revoke camera mid-session) — verify temp file is cleaned up.
- [ ] Tap retake on the preview screen — verify capture session restarts cleanly.
- [ ] Pinch-to-zoom and double-tap-to-zoom both update the preview without crashes.
- [ ] Tap-to-focus near the screen edges does not produce out-of-range coordinates.
- [ ] Replay a recorded video to the end and tap play — verify replay starts from 0.
- [ ] Open and close the player view repeatedly — confirm no observer leak via Instruments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)