### PR TITLE
fix(analysist): harden PDF rendering, observers, and presenter lifecycle

### DIFF
--- a/Oculab/Modules/Analysist/Components/BoundingBoxComponents/BoxesGroupComponent.swift
+++ b/Oculab/Modules/Analysist/Components/BoundingBoxComponents/BoxesGroupComponent.swift
@@ -24,8 +24,8 @@ struct BoxesGroupComponentView: View {
                     Color.clear
                         .contentShape(Rectangle())
                         .onTapGesture(coordinateSpace: .local) { location in
-                            print("User tapped at: \(location)")
-                            
+                            Logger.debug("User tapped at: \(location)", category: .examination)
+
                             // Provide haptic feedback
                             let impactFeedback = UIImpactFeedbackGenerator(style: .light)
                             impactFeedback.impactOccurred()

--- a/Oculab/Modules/Analysist/Components/ZoomableImageComponent.swift
+++ b/Oculab/Modules/Analysist/Components/ZoomableImageComponent.swift
@@ -54,9 +54,16 @@ struct ZoomableImageComponent: UIViewRepresentable {
               let imageView = containerView.viewWithTag(2) as? UIImageView else { return }
 
         // Only load image if it hasn't been loaded yet
-        if imageView.image == nil, let url = imageURL {
+        if imageView.image == nil, let url = imageURL, context.coordinator.imageLoadingTask == nil {
+            // Cancel any prior task before issuing a new one
+            context.coordinator.imageLoadingTask?.cancel()
+
             // Load image asynchronously
-            URLSession.shared.dataTask(with: url) { data, _, _ in
+            let task = URLSession.shared.dataTask(with: url) { [weak coordinator = context.coordinator] data, _, _ in
+                guard let coordinator = coordinator else { return }
+                // Clear the stored task once it has finished
+                defer { coordinator.imageLoadingTask = nil }
+
                 if let data = data, let image = UIImage(data: data) {
                     DispatchQueue.main.async {
                         imageView.image = image
@@ -117,7 +124,9 @@ struct ZoomableImageComponent: UIViewRepresentable {
                         }
                     }
                 }
-            }.resume()
+            }
+            context.coordinator.imageLoadingTask = task
+            task.resume()
         }
         
         // Update the BoxesGroupComponentView's zoom scale if it exists
@@ -192,9 +201,15 @@ struct ZoomableImageComponent: UIViewRepresentable {
         var currentSelectedBoxIdentifier: String?
         var boxesHostingController: UIHostingController<AnyView>?
         private var interactionResetTimer: Timer?
-        
+        var imageLoadingTask: URLSessionDataTask?
+
         init(_ parent: ZoomableImageComponent) {
             self.parent = parent
+        }
+
+        deinit {
+            interactionResetTimer?.invalidate()
+            imageLoadingTask?.cancel()
         }
         
         func updateBoxesView(with zoomScale: CGFloat, presenter: FOVDetailPresenter) {

--- a/Oculab/Modules/Analysist/Interactor/FOVDetailInteractor.swift
+++ b/Oculab/Modules/Analysist/Interactor/FOVDetailInteractor.swift
@@ -52,7 +52,7 @@ class FOVDetailInteractor {
     
     func addBox(fovId: UUID, newBox: AddBoxRequest) async throws -> APIResponse<BoxModel> {
         let fovURL = API.BE + "/boundingBox/add-bounding-box/"
-        let url = fovURL + fovId.uuidString.toLowercase()
+        let url = fovURL + fovId.uuidString.lowercased()
         let body = newBox
 
         let response: APIResponse<BoxModel> = try await networkService.update(

--- a/Oculab/Modules/Analysist/Presenter/FOVDetailPresenter.swift
+++ b/Oculab/Modules/Analysist/Presenter/FOVDetailPresenter.swift
@@ -9,7 +9,11 @@ import Foundation
 import SwiftUI
 
 class FOVDetailPresenter: ObservableObject {
-    var interactor: FOVDetailInteractor? = FOVDetailInteractor()
+    private let interactor: FOVDetailInteractor
+
+    init(interactor: FOVDetailInteractor = FOVDetailInteractor()) {
+        self.interactor = interactor
+    }
 
     @Published var zoomScale: CGFloat = 1.0
     @Published var offset: CGSize = .zero
@@ -61,6 +65,25 @@ class FOVDetailPresenter: ObservableObject {
         }
     }
 
+    @MainActor
+    func resetState() {
+        zoomScale = 1.0
+        offset = .zero
+        description = nil
+        isError = false
+        boxes = []
+        selectedBox = nil
+        fovDetail = nil
+        errorMessage = nil
+        isBoundingBoxAvailable = true
+        isBoundingBoxVisible = true
+        isAddBacilliActive = false
+        numberOfBacilli = 0
+        currentFOVId = nil
+        isCreatingNewBox = false
+        newBoxLocation = nil
+    }
+
     // functions for create new button
     func startCreatingBox(at location: CGPoint) {
         newBoxLocation = location
@@ -104,10 +127,8 @@ class FOVDetailPresenter: ObservableObject {
         guard let currentFOVId = currentFOVId else { return }
         
         do {
-            let result = try await interactor?.addBox(fovId: currentFOVId, newBox: newBox)
-            if result != nil {
-                await fetchData(fovId: currentFOVId)
-            }
+            _ = try await interactor.addBox(fovId: currentFOVId, newBox: newBox)
+            await fetchData(fovId: currentFOVId)
         } catch {
             _ = ErrorHandler.shared.handleError(error, context: .examination)
         }
@@ -121,15 +142,13 @@ class FOVDetailPresenter: ObservableObject {
     @MainActor
     func fetchData(fovId: UUID) async {
         do {
-            let result = try await interactor?.fetchData(fovId: fovId)
-            if let result {
-                currentFOVId = fovId
-                fovDetail = result
-                boxes = result.boxes.filter { $0.status != .trashed }
-                isBoundingBoxAvailable = true
-                isError = false
-                errorMessage = nil
-            }
+            let result = try await interactor.fetchData(fovId: fovId)
+            currentFOVId = fovId
+            fovDetail = result
+            boxes = result.boxes.filter { $0.status != .trashed }
+            isBoundingBoxAvailable = true
+            isError = false
+            errorMessage = nil
         } catch {
             let errorDetails = ErrorHandler.shared.handleError(error, context: .examination)
             
@@ -164,7 +183,7 @@ class FOVDetailPresenter: ObservableObject {
         }
         
         do {
-            _ = try await interactor?.verifyingFOV(fovId: fovId)
+            _ = try await interactor.verifyingFOV(fovId: fovId)
         } catch {
             let errorDetails = ErrorHandler.shared.handleError(error, context: .examination)
             errorMessage = errorDetails
@@ -178,28 +197,28 @@ class FOVDetailPresenter: ObservableObject {
             guard let index = boxes.firstIndex(where: { $0.id == boxId }) else { return }
             boxes[index].status = newStatus
 
-            let result = try await interactor?.updateBoxStatus(boxId: boxId, newStatus: newStatus.rawValue)
+            _ = try await interactor.updateBoxStatus(boxId: boxId, newStatus: newStatus.rawValue)
 
-            // If boxes updated, move selection to the next box with status .none or .flagged, else nil
-            if (result != nil) {
-                // Find the next box with status .none or .flagged, skipping the current box
-                if let currentIndex = boxes.firstIndex(where: { $0.id == boxId }) {
-                    // Search forward first
-                    let nextCandidates = boxes[(currentIndex+1)...] + boxes[..<currentIndex]
-                    if let nextBox = nextCandidates.first(where: { $0.status == .none || $0.status == .flagged }) {
-                        selectedBox = nextBox
-                    } else {
-                        selectedBox = nil
-                    }
-                } else {
-                    selectedBox = nil
-                }
+            // Move selection to the next box with status .none or .flagged, else nil
+            if let currentIndex = boxes.firstIndex(where: { $0.id == boxId }),
+               !boxes.isEmpty {
+                let safeIndex = min(currentIndex, boxes.count - 1)
+                let forwardSlice = (safeIndex + 1) < boxes.count
+                    ? Array(boxes[(safeIndex + 1)...])
+                    : []
+                let backwardSlice = safeIndex > 0
+                    ? Array(boxes[..<safeIndex])
+                    : []
+                let nextCandidates = forwardSlice + backwardSlice
+                selectedBox = nextCandidates.first(where: { $0.status == .none || $0.status == .flagged })
+            } else {
+                selectedBox = nil
             }
 
             // refetch all boxes
             guard let fovId = currentFOVId else { Logger.error("No fovId set"); return }
             await fetchData(fovId: fovId)
-            
+
         } catch {
             errorMessage = ErrorHandler.shared.handleError(error)
             isError = true

--- a/Oculab/Modules/Analysist/Presenter/PDFPresenter.swift
+++ b/Oculab/Modules/Analysist/Presenter/PDFPresenter.swift
@@ -29,4 +29,12 @@ class PDFPresenter: ObservableObject {
     func navigateToPreviousScreen() {
         Router.shared.navigateBack()
     }
+
+    @MainActor
+    func resetState() {
+        description = nil
+        isError = false
+        errorMessage = nil
+        data = nil
+    }
 }

--- a/Oculab/Modules/Analysist/View/FOVAlbum.swift
+++ b/Oculab/Modules/Analysist/View/FOVAlbum.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FOVAlbum: View {
     var fovGroup: FOVType
-    @ObservedObject var presenter: AnalysisResultPresenter = .init()
+    @StateObject private var presenter = AnalysisResultPresenter()
     var examId: String
 
     var body: some View {

--- a/Oculab/Modules/Analysist/View/FOVDetail.swift
+++ b/Oculab/Modules/Analysist/View/FOVDetail.swift
@@ -234,6 +234,9 @@ struct FOVDetail: View {
                     await presenter.verifyingFOV(fovId: fovData._id)
                 }
             }
+            .onDisappear {
+                presenter.resetState()
+            }
         }
         .navigationBarBackButtonHidden()
     }

--- a/Oculab/Modules/Analysist/View/PDFView.swift
+++ b/Oculab/Modules/Analysist/View/PDFView.swift
@@ -14,8 +14,8 @@ struct PDFPageView: View {
     
     var body: some View {
         VStack {
-            if presenter.data != nil {
-                PDFKitView(pdfDocument: PDFDocument(data: generatePDF())!)
+            if presenter.data != nil, let pdfDocument = PDFDocument(data: generatePDF()) {
+                PDFKitView(pdfDocument: pdfDocument)
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
@@ -48,6 +48,9 @@ struct PDFPageView: View {
             Task {
                 await presenter.getPdfData(examinationId: examinationId)
             }
+        }
+        .onDisappear {
+            presenter.resetState()
         }
     }
 
@@ -385,9 +388,9 @@ struct PDFPageView: View {
             let documentURL = documentDirectory.appendingPathComponent(AppTextAnalysisPDF.generatedPDFFileName)
             do {
                 try pdfData.write(to: documentURL)
-                print("PDF saved at: \(documentURL)")
+                Logger.info("PDF saved successfully", category: .examination)
             } catch {
-                print("Error saving PDF: \(error.localizedDescription)")
+                Logger.error("Error saving PDF: \(error.localizedDescription)", category: .examination)
             }
         }
     }


### PR DESCRIPTION
## Summary

Audit-driven fixes across the Analysist module — PDF rendering, image loading, FOV detail presenter, and view lifecycle.

### Critical
- **`PDFView.swift:18`** — `PDFDocument(data: generatePDF())!` could crash if PDF generation produced invalid data. Replaced with a safe conditional unwrap that falls back to the loading state.

### High
- **`ZoomableImageComponent.swift`** — the `URLSession.shared.dataTask(...)` started in `updateUIView` was never stored or cancelled. We now keep the task on the Coordinator and cancel it (along with `interactionResetTimer`) in `deinit`.
- **`FOVDetailPresenter.swift:12`** — interactor was optional but eagerly initialised, leaving `interactor?.` defensive chains everywhere. Switched to non-optional DI through the initializer.
- **`FOVAlbum.swift:12`** — `@ObservedObject var presenter: AnalysisResultPresenter = .init()` rebuilt the presenter on every re-render. Switched to `@StateObject`.

### Medium
- **`FOVDetailPresenter.updateBoxStatus`** — `boxes[(currentIndex+1)...] + boxes[..<currentIndex]` could trap when `boxes` was emptied between dispatch and execution. Added explicit bounds checks.
- **Lifecycle cleanup** — added `resetState()` to both `FOVDetailPresenter` and `PDFPresenter` and wired them to `.onDisappear` in `FOVDetail` and `PDFView` so the next presentation starts from a clean slate.
- **`FOVDetailInteractor.swift:55`** — normalised the custom `toLowercase()` extension call to the standard `lowercased()` (consistent with line 45 in the same file).
- **Logging** — replaced `print()` calls in `PDFView.savePDF` and `BoxesGroupComponent` with `Logger.*`.

### Notes
- `FOVAlbum.onDisappear { presenter.resetState() }` was deferred — `AnalysisResultPresenter.resetState()` exists on the `fix/examination-audit` branch (PR #182) but not yet on `develop`. Will be added in a follow-up once #182 lands.
- `ZoomableImageComponent.scrollViewDidZoom`'s `DispatchQueue.main.async { self.parent.zoomScale = ... }` was left intact — it intentionally defers the SwiftUI binding write to avoid \"modifying state during view update\" warnings.

## Test plan
- [ ] Open a saved exam, tap **View PDF** — confirm the PDF renders or, on a malformed payload, the loading screen stays put instead of crashing.
- [ ] Save a PDF from the share sheet — check the log shows the new \"PDF saved successfully\" message.
- [ ] Open an FOV detail, push hard back to the album, then re-open another FOV — confirm no stale boxes from the previous detail bleed in.
- [ ] Navigate into FOVDetail and back rapidly — confirm no in-flight image download keeps the Coordinator alive.
- [ ] Add a bounding box (Add Bacilli flow) — confirm it persists and the list refreshes.
- [ ] Update a box status while the boxes list happens to be empty (edge case) — confirm no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)