### PR TITLE
fix(patient): consolidate loading state, harden DI, scrub PII logs

### DIFF
--- a/Oculab/Modules/Patient/Components/PatientCard.swift
+++ b/Oculab/Modules/Patient/Components/PatientCard.swift
@@ -49,5 +49,8 @@ import SwiftUI
 }
 
 #Preview {
-    PatientCard(name: "Risa", birthDate: "2003")
+    PatientCard(
+        name: AppTextPatientCompCard.previewName,
+        birthDate: AppTextPatientCompCard.previewBirthDate
+    )
 }

--- a/Oculab/Modules/Patient/Components/PatientFormField.swift
+++ b/Oculab/Modules/Patient/Components/PatientFormField.swift
@@ -20,7 +20,10 @@ struct PatientFormField: View {
                 text: $presenter.patient.name,
                 fieldName: .patientName
             )
-            
+            .onChange(of: presenter.patient.name) {
+                presenter.handleNameChange()
+            }
+
             ValidatedTextField(
                 title: AppPatient.nik,
                 isRequired: true,
@@ -30,6 +33,9 @@ struct PatientFormField: View {
                 text: $presenter.patient.NIK,
                 fieldName: .patientNIK
             )
+            .onChange(of: presenter.patient.NIK) {
+                presenter.handleNIKChange()
+            }
 
             DateField(
                 title: AppPatient.dateOfBirth,

--- a/Oculab/Modules/Patient/Presenter/AppTextPatient.swift
+++ b/Oculab/Modules/Patient/Presenter/AppTextPatient.swift
@@ -41,6 +41,8 @@ extension AppText {
             static let birthDatePrefix = "patient.card.birth_date_prefix".localized
             static let buttonCreatePatient = AppAction.add("patient.card.button_create_patient".localized)
             static let buttonSavePatient = AppAction.save("patient.card.button_save_patient".localized)
+            static let previewName = "patient.card.preview_name".localized
+            static let previewBirthDate = "patient.card.preview_birth_date".localized
         }
         
         enum PatientFormFieldComponent {

--- a/Oculab/Modules/Patient/Presenter/PatientPresenter.swift
+++ b/Oculab/Modules/Patient/Presenter/PatientPresenter.swift
@@ -12,74 +12,83 @@ import Observation
 @Observable
 class PatientPresenter {
     // MARK: - Dependencies
-    private var interactor: PatientInteractor? = PatientInteractor()
-    
+    private let interactor: PatientInteractor
+
     // MARK: - Form Validation
     var formValidation: FormValidationViewModel
-    
+
     // MARK: - Initialization
-    init() {
+    init(interactor: PatientInteractor = PatientInteractor()) {
+        self.interactor = interactor
         self.formValidation = FormValidationViewModel()
     }
-    
+
     // MARK: - UI State
     var isPatientLoading = false
     var patientNameDoB: [(String, String)] = []
     var searchText: String = AppConstants.PatientUI.defaultEmptyValue
     var filteredPatientNameDoB: [(String, String)] = []
-    
-    // MARK: - Patient Data with Validation
+
+    // MARK: - Patient Data
     var patient: Patient = .init(
         _id: UUID().uuidString.lowercased(),
         name: AppConstants.PatientUI.defaultEmptyValue,
         NIK: AppConstants.PatientUI.defaultEmptyValue,
         DoB: Date(),
         sex: .UNKNOWN
-    ) {
-        didSet {
-            validatePatientFields()
-        }
-    }
-    
+    )
+
     var selectedSex: String = AppConstants.PatientUI.defaultEmptyValue
-    var BPJSnumber: String = AppConstants.PatientUI.defaultEmptyValue {
-        didSet {
-            validateBPJSField()
-        }
-    }
+    var BPJSnumber: String = AppConstants.PatientUI.defaultEmptyValue
     var selectedDoB: Date = Date()
-    
+
     // MARK: - Validation Error States
     var nameError: String = AppConstants.PatientUI.defaultEmptyValue
     var nikError: String = AppConstants.PatientUI.defaultEmptyValue
     var bpjsError: String = AppConstants.PatientUI.defaultEmptyValue
-    
+
     // MARK: - Other States
     var examinationList: [ExaminationResultCardData] = []
-    var isLoadingPatient: Bool = false
     var isLoadingExaminations: Bool = false
     var errorMessage: String?
-    
+
+    // Explicit edit-mode flag, set when an existing patient has been loaded.
+    private var isEditMode: Bool = false
+
+    // MARK: - Task Handles (for cancellation on view disappear)
+    private var fetchTask: Task<Void, Never>?
+    private var examinationsTask: Task<Void, Never>?
+
     // MARK: - Computed Properties
     var isFormValid: Bool {
         return validatePatientForm() && !isPatientLoading
     }
-    
+
     // MARK: - Form View Properties
     var buttonTitle: String {
         isAddingNewPatient ? AppTextPatientCompCard.buttonCreatePatient : AppTextPatientCompCard.buttonSavePatient
     }
-    
+
     var buttonIcon: String {
         isAddingNewPatient ? AppIcon.add : AppIcon.checkmark
     }
-    
+
     var navigationTitle: String {
         isAddingNewPatient ? AppTextPatientForm.newPatientNavigationTitle : AppTextPatientForm.editPatientNavigationTitle
     }
-    
+
     private var isAddingNewPatient: Bool {
-        return patient._id.isEmpty || patient.name.isEmpty
+        return !isEditMode
+    }
+
+    // MARK: - Lifecycle
+    @MainActor
+    func resetState() {
+        fetchTask?.cancel()
+        fetchTask = nil
+        examinationsTask?.cancel()
+        examinationsTask = nil
+        errorMessage = nil
     }
 }
 
@@ -87,11 +96,12 @@ class PatientPresenter {
 extension PatientPresenter {
     func setupForm(patientId: String?) {
         guard let patientId = patientId else { return }
-        Task {
-            await getPatientById(patientId: patientId)
+        fetchTask?.cancel()
+        fetchTask = Task { [weak self] in
+            await self?.getPatientById(patientId: patientId)
         }
     }
-    
+
     func handleFormSubmission() async {
         if isAddingNewPatient {
             await addNewPatientWithValidation()
@@ -99,13 +109,21 @@ extension PatientPresenter {
             await updatePatientWithValidation()
         }
     }
-    
+
     // MARK: - Field Change Handlers
+    func handleNameChange() {
+        validateNameField()
+    }
+
+    func handleNIKChange() {
+        validateNIKField()
+    }
+
     func handleDateOfBirthChange() {
         patient.DoB = selectedDoB
         Logger.debug("Date of birth updated", category: .patient)
     }
-    
+
     func handleGenderChange() {
         switch selectedSex {
         case AppPatient.Gender.female:
@@ -115,12 +133,12 @@ extension PatientPresenter {
         default:
             patient.sex = .UNKNOWN
         }
-        Logger.debug("Gender updated to: \(patient.sex)", category: .patient)
+        Logger.debug("Gender updated", category: .patient)
     }
-    
+
     func handleBPJSChange() {
         patient.BPJS = BPJSnumber.isEmpty ? nil : BPJSnumber
-        Logger.debug("BPJS number updated", category: .patient)
+        validateBPJSField()
     }
 
     func dismissKeyboard() {
@@ -137,12 +155,7 @@ extension PatientPresenter {
             bpjs: BPJSnumber.isEmpty ? nil : BPJSnumber
         )
     }
-    
-    private func validatePatientFields() {
-        validateNameField()
-        validateNIKField()
-    }
-    
+
     private func validateNameField() {
         if !patient.name.isEmpty {
             let isValid = ValidationManager.shared.validateName(patient.name, fieldName: ValidationFieldName.patientName.rawValue)
@@ -152,7 +165,7 @@ extension PatientPresenter {
             ValidationManager.shared.clearError(for: ValidationFieldName.patientName.rawValue)
         }
     }
-    
+
     private func validateNIKField() {
         if !patient.NIK.isEmpty {
             let isValid = ValidationManager.shared.validateNIK(patient.NIK, fieldName: ValidationFieldName.patientNIK.rawValue)
@@ -162,7 +175,7 @@ extension PatientPresenter {
             ValidationManager.shared.clearError(for: ValidationFieldName.patientNIK.rawValue)
         }
     }
-    
+
     private func validateBPJSField() {
         if !BPJSnumber.isEmpty {
             let isValid = ValidationManager.shared.validateWithRules(BPJSnumber, fieldName: ValidationFieldName.patientBPJS.rawValue, rules: [
@@ -186,22 +199,22 @@ extension PatientPresenter {
             Logger.warning("Patient form validation failed", category: .patient)
             return
         }
-        
+
         formValidation.clearAllErrors()
         await addNewPatient()
     }
-    
+
     @MainActor
     func updatePatientWithValidation() async {
         guard validatePatientForm() else {
             Logger.warning("Patient form validation failed", category: .patient)
             return
         }
-        
+
         formValidation.clearAllErrors()
         await updatePatient()
     }
-    
+
     @MainActor
     func getAllPatient() async {
         isPatientLoading = true
@@ -210,23 +223,21 @@ extension PatientPresenter {
         }
 
         do {
-            let response = try await interactor?.getAllPatient()
+            let response = try await interactor.getAllPatient()
 
-            if let response {
-                patientNameDoB.removeAll()
-                for patient in response {
-                    let formattedDoB = formatDate(patient.DoB)
-                    patientNameDoB.append((patient.name + String(formattedDoB), patient._id))
-                }
-                filterPatients()
-                Logger.info("Successfully fetched \(response.count) patients", category: .patient)
+            patientNameDoB.removeAll()
+            for patient in response {
+                let formattedDoB = formatDate(patient.DoB)
+                patientNameDoB.append((patient.name + String(formattedDoB), patient._id))
             }
+            filterPatients()
+            Logger.info("Successfully fetched \(response.count) patients", category: .patient)
         } catch {
             errorMessage = ErrorHandler.shared.handleError(error)
             Logger.error("Failed to fetch patients: \(error.localizedDescription)", category: .patient)
         }
     }
-    
+
     @MainActor
     func getPatientById(patientId: String) async {
         isPatientLoading = true
@@ -235,26 +246,25 @@ extension PatientPresenter {
         }
 
         do {
-            let response = try await interactor?.getPatientById(patientId: patientId)
+            let fetchedPatient = try await interactor.getPatientById(patientId: patientId)
 
-            if let fetchedPatient = response {
-                self.patient = fetchedPatient
-                self.BPJSnumber = fetchedPatient.BPJS ?? AppConstants.PatientUI.defaultEmptyValue
-                self.selectedDoB = fetchedPatient.DoB ?? Date()
-                
-                switch fetchedPatient.sex {
-                case .FEMALE:
-                    self.selectedSex = AppPatient.Gender.female
-                case .MALE:
-                    self.selectedSex = AppPatient.Gender.male
-                default:
-                    self.selectedSex = AppConstants.PatientUI.defaultEmptyValue
-                }
-                Logger.info("Successfully fetched patient with ID: \(patientId)", category: .patient)
+            self.patient = fetchedPatient
+            self.BPJSnumber = fetchedPatient.BPJS ?? AppConstants.PatientUI.defaultEmptyValue
+            self.selectedDoB = fetchedPatient.DoB ?? Date()
+            self.isEditMode = true
+
+            switch fetchedPatient.sex {
+            case .FEMALE:
+                self.selectedSex = AppPatient.Gender.female
+            case .MALE:
+                self.selectedSex = AppPatient.Gender.male
+            default:
+                self.selectedSex = AppConstants.PatientUI.defaultEmptyValue
             }
+            Logger.info("Successfully fetched patient", category: .patient)
         } catch {
             errorMessage = ErrorHandler.shared.handleError(error)
-            Logger.error("Failed to fetch patient with ID \(patientId): \(error.localizedDescription)", category: .patient)
+            Logger.error("Failed to fetch patient: \(error.localizedDescription)", category: .patient)
         }
     }
 
@@ -264,32 +274,30 @@ extension PatientPresenter {
         defer {
             isPatientLoading = false
         }
-        
+
         patient.DoB = selectedDoB
         patient.BPJS = BPJSnumber.isEmpty ? nil : BPJSnumber
-        
+
         do {
-            let response = try await interactor?.addNewPatient(patient: patient)
-            if response != nil {
-                Logger.info("Successfully added new patient: \(patient.name)", category: .patient)
-                Router.shared.navigateBack()
-            }
+            _ = try await interactor.addNewPatient(patient: patient)
+            Logger.info("Successfully added new patient", category: .patient)
+            Router.shared.navigateBack()
         } catch {
             errorMessage = ErrorHandler.shared.handleError(error)
             Logger.error("Failed to add new patient: \(error.localizedDescription)", category: .patient)
         }
     }
-    
+
     @MainActor
     func updatePatient() async {
         isPatientLoading = true
         defer {
             isPatientLoading = false
         }
-        
+
         patient.DoB = selectedDoB
         patient.BPJS = BPJSnumber.isEmpty ? nil : BPJSnumber
-        
+
         switch selectedSex {
         case AppPatient.Gender.female:
             patient.sex = .FEMALE
@@ -298,15 +306,13 @@ extension PatientPresenter {
         default:
             patient.sex = .UNKNOWN
         }
-        
-        do {
-            let response = try await interactor?.updatePatient(patient: patient, patientId: String(describing: patient._id))
 
-            if let updatedPatient = response {
-                self.patient = updatedPatient
-                Logger.info("Successfully updated patient: \(patient.name)", category: .patient)
-                Router.shared.navigateBack()
-            }
+        do {
+            let updatedPatient = try await interactor.updatePatient(patient: patient, patientId: String(describing: patient._id))
+
+            self.patient = updatedPatient
+            Logger.info("Successfully updated patient", category: .patient)
+            Router.shared.navigateBack()
         } catch {
             errorMessage = ErrorHandler.shared.handleError(error)
             Logger.error("Failed to update patient: \(error.localizedDescription)", category: .patient)
@@ -319,12 +325,12 @@ extension PatientPresenter {
     func searchPatients() {
         filterPatients()
     }
-    
+
     func clearSearch() {
         searchText = AppConstants.PatientUI.defaultEmptyValue
         filterPatients()
     }
-    
+
     private func filterPatients() {
         if searchText.isEmpty {
             filteredPatientNameDoB = patientNameDoB
@@ -343,20 +349,16 @@ extension PatientPresenter {
     func getExaminationsByPatientId(patientId: String) async {
         isLoadingExaminations = true
         defer { isLoadingExaminations = false }
-        
-        do {
-            Logger.info("Fetching examinations for patient: \(patientId)", category: .patient)
-            let response = try await interactor?.getAllExamByPatientId(patientId: patientId)
-            
-            if let examinations = response {
-                Logger.info("Successfully received \(examinations.count) examinations", category: .patient)
-                self.examinationList = examinations
-            }
 
+        do {
+            Logger.info("Fetching examinations for patient", category: .patient)
+            let examinations = try await interactor.getAllExamByPatientId(patientId: patientId)
+
+            Logger.info("Successfully received \(examinations.count) examinations", category: .patient)
+            self.examinationList = examinations
         } catch {
             errorMessage = ErrorHandler.shared.handleError(error)
-            Logger.error("Failed to fetch examinations for patient \(patientId): \(error.localizedDescription)", category: .patient)
-            isLoadingExaminations = false
+            Logger.error("Failed to fetch examinations: \(error.localizedDescription)", category: .patient)
         }
     }
 }
@@ -366,7 +368,7 @@ extension PatientPresenter {
     func navigateTo(_ destination: Router.Route) {
         Router.shared.navigateTo(destination)
     }
-    
+
     func navigateBack() {
         Router.shared.navigateBack()
     }
@@ -374,18 +376,26 @@ extension PatientPresenter {
 
 // MARK: - Helper Methods
 extension PatientPresenter {
-    func formatDate(_ date: Date?) -> String {
-        guard let date = date else { return AppConstants.PatientUI.defaultEmptyValue }
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale.current
         formatter.dateFormat = AppConstants.PatientUI.dateFormat
-        return formatter.string(from: date)
-    }
-    
-    func formatDateTime(_ date: Date) -> String {
+        return formatter
+    }()
+
+    private static let dateTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale.current
         formatter.dateFormat = AppConstants.PatientUI.dateTimeFormat
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    func formatDate(_ date: Date?) -> String {
+        guard let date = date else { return AppConstants.PatientUI.defaultEmptyValue }
+        return Self.dateFormatter.string(from: date)
+    }
+
+    func formatDateTime(_ date: Date) -> String {
+        return Self.dateTimeFormatter.string(from: date)
     }
 }

--- a/Oculab/Modules/Patient/View/PatientDetailView.swift
+++ b/Oculab/Modules/Patient/View/PatientDetailView.swift
@@ -14,7 +14,7 @@ struct PatientDetailView: View {
     var body: some View {
         NavigationView {
             ScrollView {
-                if !presenter.isLoadingPatient && !presenter.patient.name.isEmpty {
+                if !presenter.isPatientLoading && !presenter.patient.name.isEmpty {
                     Spacer().frame(height: Decimal.d24)
                     
                     AppCard(icon: AppIcon.personFill, title: AppTextPatientDetail.patientDataTitle, spacing: Decimal.d16, isEnablingEdit: true) {
@@ -71,7 +71,7 @@ struct PatientDetailView: View {
                             }
                         }
                     }
-                } else if presenter.isLoadingPatient {
+                } else if presenter.isPatientLoading {
                     ProgressView(AppTextPatientDetail.loadingPatientMessage)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
@@ -95,6 +95,9 @@ struct PatientDetailView: View {
                     await presenter.getPatientById(patientId: patientId)
                     await presenter.getExaminationsByPatientId(patientId: patientId)
                 }
+            }
+            .onDisappear {
+                presenter.resetState()
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/Oculab/Modules/Patient/View/PatientFormView.swift
+++ b/Oculab/Modules/Patient/View/PatientFormView.swift
@@ -59,6 +59,9 @@ struct PatientFormView: View {
             .onAppear {
                 presenter.setupForm(patientId: patientId)
             }
+            .onDisappear {
+                presenter.resetState()
+            }
             .alert(AppValue.unknownError, isPresented: Binding(
                 get: { presenter.errorMessage != nil },
                 set: { _ in presenter.errorMessage = nil }

--- a/Oculab/Modules/Patient/View/PatientListView.swift
+++ b/Oculab/Modules/Patient/View/PatientListView.swift
@@ -92,6 +92,9 @@ struct PatientListView: View {
                     await presenter.getAllPatient()
                 }
             }
+            .onDisappear {
+                presenter.resetState()
+            }
             .onChange(of: presenter.searchText) { _, _ in
                 presenter.searchPatients()
             }

--- a/Oculab/en.lproj/Localizable.strings
+++ b/Oculab/en.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "patient.card.birth_date_prefix" = "Date of Birth: ";
 "patient.card.button_create_patient" = "New Patient";
 "patient.card.button_save_patient" = "Patient Data";
+"patient.card.preview_name" = "Patient Name";
+"patient.card.preview_birth_date" = "01/01/2000";
 
 // Patient Form Field Component
 "patient.form_field.name_placeholder" = "John Doe";

--- a/Oculab/id.lproj/Localizable.strings
+++ b/Oculab/id.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "patient.card.birth_date_prefix" = "Tanggal Lahir: ";
 "patient.card.button_create_patient" = "Pasien Baru";
 "patient.card.button_save_patient" = "Data Pasien";
+"patient.card.preview_name" = "Nama Pasien";
+"patient.card.preview_birth_date" = "01/01/2000";
 
 // Patient Form Field Component
 "patient.form_field.name_placeholder" = "John Doe";


### PR DESCRIPTION
## Summary

Patient module audit — 9 findings shipped together.

- **Loading state consolidation:** removed duplicate `isLoadingPatient`/`isPatientLoading`; PatientDetailView now reads the single source of truth.
- **DI:** `PatientInteractor` is non-optional with init-injected default; removes guard noise on every call site.
- **Validation:** moved off cascading `didSet` observers on `patient`/`BPJSnumber`. Explicit `handleNameChange`, `handleNIKChange`, `handleBPJSChange` handlers fire from `.onChange` in `PatientFormField`.
- **Add vs edit detection:** explicit `isEditMode` flag set after a successful patient fetch, replacing the `name.isEmpty` heuristic that misfired on fresh placeholder data.
- **Lifecycle:** added `resetState()` with `Task.cancel()`, wired to `onDisappear` in `PatientDetailView`, `PatientListView`, `PatientFormView`.
- **Redundant state:** dropped `isLoadingExaminations = false` in catch — `defer` already handles it.
- **PII scrub:** removed `patient.name`, `patientId`, NIK from Logger calls (~9 sites).
- **Performance:** cached `DateFormatter`s as static properties; `formatDate`/`formatDateTime` no longer allocate per call.
- **Preview hygiene:** replaced hardcoded "Risa"/"2003" in `PatientCard` preview with localized `AppTextPatientCompCard.previewName`/`previewBirthDate` (added en + id strings).

## Test plan

- [ ] `xcodebuild` succeeds against iPhone 17 simulator (verified locally — `** BUILD SUCCEEDED **`).
- [ ] Patient list loads and search filters as before.
- [ ] Patient detail screen shows patient + examinations; navigating back cancels in-flight tasks.
- [ ] Patient form: create new patient (button title "New Patient", icon `add`).
- [ ] Patient form: edit existing patient (button title "Patient Data", icon `checkmark`) — confirms isEditMode flag flips correctly after fetch.
- [ ] Form validation: name/NIK/BPJS errors show inline as user types (validation now runs from .onChange, not didSet).
- [ ] Form submit: invalid inputs blocked; valid inputs save and navigate back.
- [ ] No `patient.name` / NIK / BPJS appears in console logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)