### PR TITLE
fix(home-history): non-optional interactor, task cancellation, force-unwrap

### DIFF
--- a/Oculab/Modules/HomeHistory/Components/HalfCircleProgress.swift
+++ b/Oculab/Modules/HomeHistory/Components/HalfCircleProgress.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-import SwiftUI
-
 struct HalfCircleProgress: View {
     var progress: CGFloat
 

--- a/Oculab/Modules/HomeHistory/Components/StatisticComponent.swift
+++ b/Oculab/Modules/HomeHistory/Components/StatisticComponent.swift
@@ -27,7 +27,6 @@ struct StatisticComponent: View {
                 HStack(spacing: Decimal.d32) {
                     HalfCircleProgress(progress: presenter.progress)
                         .offset(y: 35)
-                    // TODO: Create func to create sentence
                     VStack(alignment: .leading, spacing: Decimal.d4) {
                         Text(AppData.makeSentence([presenter.statisticExam.totalFinished ?? 0, AppTextHomeHistCompStatistic.tasksCompletedSuffix])).font(AppTypography.h4_1)
                         Text(

--- a/Oculab/Modules/HomeHistory/Components/WeeklyCalendar.swift
+++ b/Oculab/Modules/HomeHistory/Components/WeeklyCalendar.swift
@@ -164,7 +164,11 @@ struct WeeklyCalendar: View {
         let calendar = Calendar.current
         var weekDates: [Date] = []
 
-        let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date))!
+        guard let startOfWeek = calendar.date(
+            from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        ) else {
+            return [date]
+        }
 
         for i in 0..<Constants.daysInWeek {
             if let weekDate = calendar.date(byAdding: .day, value: i, to: startOfWeek) {

--- a/Oculab/Modules/HomeHistory/Presenter/HomeHistoryPresenter.swift
+++ b/Oculab/Modules/HomeHistory/Presenter/HomeHistoryPresenter.swift
@@ -10,7 +10,11 @@ import Foundation
 class HomeHistoryPresenter: ObservableObject {
     // MARK: - Dependencies
     var view: HomeView?
-    private var interactor: HomeInteractor? = HomeInteractor()
+    private let interactor: HomeInteractor
+
+    init(interactor: HomeInteractor = HomeInteractor()) {
+        self.interactor = interactor
+    }
 
     // MARK: - Published Properties
     @Published var selectedLatestActivity: LatestActivityType = .belumDimulai
@@ -46,13 +50,8 @@ extension HomeHistoryPresenter {
         defer { isStatisticLoading = false }
 
         do {
-            let data = try await interactor?.getStatisticExamination()
-
-            if let data {
-                statisticExam = data
-                calculateProgress()
-            }
-            
+            statisticExam = try await interactor.getStatisticExamination()
+            calculateProgress()
         } catch {
             Logger.error("Failed to fetch statistics: \(error.localizedDescription)", category: .general)
             _ = ErrorHandler.shared.handleError(error)
@@ -130,7 +129,7 @@ extension HomeHistoryPresenter {
         defer { isAllExamsLoading = false }
         
         do {
-            let response = try await interactor?.getFinishedDataCard(date: dateString)
+            let response = try await interactor.getFinishedDataCard(date: dateString)
             
             handleFinishedExaminationsResponse(response, for: dateString)
             
@@ -141,14 +140,9 @@ extension HomeHistoryPresenter {
         }
     }
     
-    private func handleFinishedExaminationsResponse(_ response: [FinishedExaminationCardData]?, for dateString: String) {
-        if let response = response, !response.isEmpty {
-            finishedExaminationsByDate = response
-            Logger.info("Successfully loaded \(response.count) examinations for date: \(dateString)", category: .general)
-        } else {
-            finishedExaminationsByDate = []
-            Logger.info("No examinations found for date: \(dateString)", category: .general)
-        }
+    private func handleFinishedExaminationsResponse(_ response: [FinishedExaminationCardData], for dateString: String) {
+        finishedExaminationsByDate = response
+        Logger.info("Loaded \(response.count) examinations", category: .general)
     }
     
     @MainActor
@@ -157,23 +151,36 @@ extension HomeHistoryPresenter {
         defer { isAllExamsLoading = false }
 
         do {
-            let response = try await getExaminationData(for: userRole)
-            
-            if let response {
-                latestExamination = response
-                await filterLatestActivity(typeActivity: selectedLatestActivity)
-            }
+            latestExamination = try await getExaminationData(for: userRole)
+            await filterLatestActivity(typeActivity: selectedLatestActivity)
         } catch {
             Logger.error("Failed to fetch examination data for role \(userRole): \(error.localizedDescription)", category: .general)
             _ = ErrorHandler.shared.handleError(error)
         }
     }
     
-    private func getExaminationData(for userRole: RolesType) async throws -> [ExaminationCardData]? {
+    private func getExaminationData(for userRole: RolesType) async throws -> [ExaminationCardData] {
         if userRole == .ADMIN {
-            return try await interactor?.getAllDataAdmin()
+            return try await interactor.getAllDataAdmin()
         } else {
-            return try await interactor?.getAllData()
+            return try await interactor.getAllData()
         }
+    }
+}
+
+// MARK: - State Management
+extension HomeHistoryPresenter {
+    @MainActor
+    func resetState() {
+        latestExamination = []
+        filteredExamination = []
+        filteredExaminationByDate = []
+        finishedExaminationsByDate = []
+        unfinishedExaminationsByDate = []
+        statisticExam = .init()
+        progress = 0.0
+        isAllExamsLoading = false
+        isStatisticLoading = false
+        selectedLatestActivity = .belumDimulai
     }
 }

--- a/Oculab/Modules/HomeHistory/View/HistoryView.swift
+++ b/Oculab/Modules/HomeHistory/View/HistoryView.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 struct HistoryView: View {
-    @ObservedObject private var presenter = HomeHistoryPresenter()
+    @StateObject private var presenter = HomeHistoryPresenter()
     @State var selectedDate: Date
-    
+
     @State private var currentlyLoadedDate: Date?
+    @State private var loadTask: Task<Void, Never>?
 
     var body: some View {
         NavigationView {
@@ -72,6 +73,9 @@ struct HistoryView: View {
                 loadDataForDate(newValue)
             }
         }
+        .onDisappear {
+            loadTask?.cancel()
+        }
         .navigationBarBackButtonHidden(true)
     }
     
@@ -84,8 +88,9 @@ struct HistoryView: View {
     
     private func loadDataForDate(_ date: Date) {
         currentlyLoadedDate = date
-        
-        Task {
+
+        loadTask?.cancel()
+        loadTask = Task {
             await presenter.fetchFinishedExaminationsByDate(date: date)
         }
     }

--- a/Oculab/Modules/HomeHistory/View/HomeView.swift
+++ b/Oculab/Modules/HomeHistory/View/HomeView.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct HomeView: View {
-    @ObservedObject private var presenter = HomeHistoryPresenter()
+    @StateObject private var presenter = HomeHistoryPresenter()
     @EnvironmentObject private var authentication: AuthenticationPresenter
+    @State private var loadTask: Task<Void, Never>?
+    @State private var refreshTask: Task<Void, Never>?
 
     var body: some View {
         NavigationView {
@@ -117,10 +119,12 @@ struct HomeView: View {
                 .padding(.bottom, 20)
             }
             .refreshable {
-                Task {
+                refreshTask?.cancel()
+                refreshTask = Task {
                     await presenter.getStatisticData()
                     await presenter.fetchData(userRole: authentication.user.role)
                 }
+                await refreshTask?.value
             }
             .navigationTitle(AppTextHomeHistory.navigationTitleHome)
             .toolbar {
@@ -131,10 +135,15 @@ struct HomeView: View {
         }
         .ignoresSafeArea()
         .onAppear {
-            Task {
+            loadTask?.cancel()
+            loadTask = Task {
                 await presenter.getStatisticData()
                 await presenter.fetchData(userRole: authentication.user.role)
             }
+        }
+        .onDisappear {
+            loadTask?.cancel()
+            refreshTask?.cancel()
         }
         .navigationBarBackButtonHidden(true)
     }


### PR DESCRIPTION
## Summary

Mechanical fixes from the HomeHistory module audit. No architectural changes.

### Fixes
- **Force-unwrap** in `WeeklyCalendar.getWeek` — `calendar.date(from:)!` could crash on a malformed component bag; now `guard` with fallback to `[date]`.
- **Optional interactor** anti-pattern — `HomeHistoryPresenter` had `var interactor: HomeInteractor? = HomeInteractor()` and called every method as `interactor?.foo()`. Replaced with `private let interactor: HomeInteractor` + DI init. Since `HomeInteractor` returns non-optional arrays, the receiving `if let response { ... }` blocks collapsed away too.
- **`@ObservedObject` → `@StateObject`** in `HomeView` and `HistoryView` so the presenter isn't recreated on parent re-render.
- **Task leaks** — added `Task<Void, Never>?` handles for load/refresh tasks in both views; cancel prior task on each `onAppear`/`onChange`/`refreshable`; cancel everything in `onDisappear`.
- **`resetState()`** added to `HomeHistoryPresenter` for parity with Patient/Examination/Analysist presenters.
- **Log noise** — collapsed `handleFinishedExaminationsResponse` to log only count, drop date string and the empty-vs-nonempty branch (the assignment is the same either way).
- **Duplicate `import SwiftUI`** in `HalfCircleProgress.swift` removed.
- **Dead `// TODO: Create func to create sentence`** removed from `StatisticComponent` — the inline `AppData.makeSentence(...)` is the pattern used elsewhere; the TODO doesn't describe an actionable bug.

### Skipped from audit
- Magic numbers `100/45/75/300/40` in `HalfCircleProgress`/`WeeklyCalendar` — `Decimal` enum doesn't currently have `d40/d45/d75/d100/d300`; adding 5 constants for one component is more churn than the fix is worth, and these are intentional fixed dimensions (component shape, calendar width).
- "PII logging on date strings" — date strings are not PII.

## Test plan
- [ ] Open HomeView (lab and admin role) — statistics + tasks list load
- [ ] Pull-to-refresh while a fetch is in flight — no crash, latest result wins
- [ ] Open HistoryView, swipe weeks, tap dates — finished exams load per date
- [ ] Background/foreground a date change rapidly — no zombie tasks
- [ ] WeeklyCalendar with `selectedDate` near year boundary — no crash from previously-force-unwrapped `dateComponents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)