### PR TITLE
fix(user-management): print → Logger, plug task leaks, reset form on disappear

### DIFF
--- a/Oculab/Modules/UserManagement/Presenter/AccountPresenter.swift
+++ b/Oculab/Modules/UserManagement/Presenter/AccountPresenter.swift
@@ -12,6 +12,7 @@ class AccountPresenter: ObservableObject {
     private var interactor: AccountInteractor
     private var searchTimer: Timer?
     private var debounceTime: TimeInterval = 0.3
+    private var refetchTask: Task<Void, Never>?
     
     // MARK: - Form Validation
     var formValidation: FormValidationViewModel
@@ -100,6 +101,7 @@ class AccountPresenter: ObservableObject {
     
     deinit {
         searchTimer?.invalidate()
+        refetchTask?.cancel()
     }
 }
 
@@ -185,21 +187,21 @@ extension AccountPresenter {
     @MainActor
     func registerNewAccountWithValidation(role: String, name: String, email: String) async {
         guard validateUserForm() else {
-            print("🔘 User form validation failed")
+            Logger.warning("User form validation failed", category: .general)
             return
         }
-        
+
         formValidation.clearAllErrors()
         await registerNewAccount(role: role, name: name, email: email)
     }
-    
+
     @MainActor
     func editSelectedUserWithValidation(role: String, name: String, userId: String) async {
         guard validateUserForm() else {
-            print("🔘 User form validation failed")
+            Logger.warning("User form validation failed", category: .general)
             return
         }
-        
+
         formValidation.clearAllErrors()
         await editSelectedUser(role: role, name: name, userId: userId)
     }
@@ -242,13 +244,14 @@ extension AccountPresenter {
             // Registration successful - result is non-nil
             registrationSuccess = (name: name, role: roleType.rawValue)
             showSuccessPopup = true
-            
-            Task {
-                await fetchAllAccount()
+
+            refetchTask?.cancel()
+            refetchTask = Task { [weak self] in
+                await self?.fetchAllAccount()
             }
-            
+
             clearForm()
-            
+
         } catch {
             registrationError = ErrorHandler.shared.handleError(error)
         }
@@ -269,11 +272,12 @@ extension AccountPresenter {
             selectedUser = SelectedUser(id: result.id, name: result.name)
             editSuccess = (name: name, role: role)
             showSuccessPopup = true
-            
-            Task {
-                await fetchAllAccount()
+
+            refetchTask?.cancel()
+            refetchTask = Task { [weak self] in
+                await self?.fetchAllAccount()
             }
-            
+
         } catch {
             editError = ErrorHandler.shared.handleError(error)
         }

--- a/Oculab/Modules/UserManagement/View/EditUserFormView.swift
+++ b/Oculab/Modules/UserManagement/View/EditUserFormView.swift
@@ -71,8 +71,7 @@ struct EditUserFormView: View {
                                 placeholder: AppTextUserMgmtEditUserForm.emailPlaceholder,
                                 isDisabled: true,
                                 text: .constant(account.email),
-                                fieldName: .userEmail,
-                                validationType: .email
+                                fieldName: .userEmail
                             )
 
                             // Save button
@@ -147,6 +146,9 @@ struct EditUserFormView: View {
         )
         .onAppear {
             presenter.setAccount(account: account)
+        }
+        .onDisappear {
+            presenter.resetForm()
         }
     }
 }

--- a/Oculab/Modules/UserManagement/View/NewUserFormView.swift
+++ b/Oculab/Modules/UserManagement/View/NewUserFormView.swift
@@ -145,6 +145,9 @@ struct NewUserFormView: View {
                 Text(presenter.registrationError ?? AppValue.unknownError)
             }
         )
+        .onDisappear {
+            presenter.resetForm()
+        }
     }
 }
 

--- a/Oculab/Modules/UserManagement/View/UserManagementView.swift
+++ b/Oculab/Modules/UserManagement/View/UserManagementView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct UserManagementView: View {
     @EnvironmentObject var presenter: AccountPresenter
-    
+    @State private var fetchTask: Task<Void, Never>?
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -148,9 +149,13 @@ struct UserManagementView: View {
                     }
                 )
                 .onAppear {
-                    Task {
+                    fetchTask?.cancel()
+                    fetchTask = Task {
                         await presenter.fetchAllAccount()
                     }
+                }
+                .onDisappear {
+                    fetchTask?.cancel()
                 }
             }
         }


### PR DESCRIPTION
## Summary

Mechanical fixes from the UserManagement module audit. Architectural findings (route-level authorization, per-route presenter instantiation) deferred to follow-ups since they need design review.

### Fixes
- **`print` → Logger** — 2x `print(\"🔘 User form validation failed\")` in `registerNewAccountWithValidation` / `editSelectedUserWithValidation` replaced with `Logger.warning(..., category: .general)`.
- **Refetch task leak** — `registerNewAccount` / `editSelectedUser` launched bare `Task { await fetchAllAccount() }` after success. Added `refetchTask: Task<Void, Never>?` on the presenter; cancel prior task before respawn; cancel in `deinit`. Capture is `[weak self]` since this is the only fire-and-forget path that can outlive the presenter.
- **Fetch task leak in `UserManagementView`** — `onAppear` was firing an uncancelled `Task`. Now stored as `@State fetchTask`, cancelled on re-entry and on `onDisappear`.
- **Form state bleeds across navigations** — Added `.onDisappear { presenter.resetForm() }` to both `NewUserFormView` and `EditUserFormView`. Previously the success popup binding was the only path that reset the form, which doesn't fire on swipe-back or rapid row taps.
- **Disabled email field with bogus validator** — `EditUserFormView` bound the email field to `.constant(account.email)` with `isDisabled: true` but still passed `validationType: .email`. Validation can never fire on a constant; removed the parameter.

### Deferred (not in this PR)
- **Authorization gap** — `.accountManagement`, `.newAccount`, `.editAccount` routes only check `requiresAuthentication: true`. UI hides the entry button for non-ADMINs, but the Router itself doesn't gate by `user.role == .ADMIN`. A determined caller could push these routes via deeplink/state. Backend authorization should be the source of truth, but a defense-in-depth client check belongs at the Router.
- **Per-route presenter instantiation** — `DependencyInjection.shared.createAccountPresenter()` builds a new presenter for each of the three routes, so search debounce, grouped accounts, and form state are dropped on every transition. Refactoring this touches DI lifecycle.

## Test plan
- [ ] Admin → User Management → list loads
- [ ] Search w/ debounce — typing fast doesn't fire stale searches
- [ ] Add new user → success popup → \"create another\" resets form
- [ ] Add new user → swipe back from form mid-entry → re-enter form → fields are empty
- [ ] Edit user → save → list refreshes; popup back-to-list nav doesn't carry stale name/role
- [ ] Tap user row A → BottomSheetMenu → close → tap user row B → edit form pre-populates with B's data, not A's
- [ ] Pop UserManagementView mid-fetch — no zombie tasks (`fetchTask` cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)