### PR TITLE
fix(task-assignment): scrub PII logs, fix silent submit guard, plug task leaks

### DIFF
--- a/Oculab/Modules/TaskAssignment/Presenter/InputPatientPresenter.swift
+++ b/Oculab/Modules/TaskAssignment/Presenter/InputPatientPresenter.swift
@@ -31,6 +31,7 @@ class InputPatientPresenter: ObservableObject {
     @Published var errorMessage: String = AppValue.empty
     @Published var isUserLoading = false
     @Published var isPatientLoading = false
+    @Published var isSubmittingExamination = false
     @Published var isSubmitPopUpVisible: Bool = false
     @Published var isSlide2Visible: Bool = false
     // MARK: - Slide 2 UI Logic
@@ -146,7 +147,7 @@ class InputPatientPresenter: ObservableObject {
     
     // MARK: - Helper Methods
     private func updatePatientForm() {
-        Logger.info("Patient found - DoB: \(String(describing: patient.DoB)), Sex: \(patient.sex), BPJS: \(String(describing: patient.BPJS))", category: .taskAssignment)
+        Logger.info("Patient record loaded", category: .taskAssignment)
         selectedDoB = patient.DoB ?? Date()
         selectedSex = patient.sex == .MALE ? AppPatient.Gender.male : 
                      patient.sex == .FEMALE ? AppPatient.Gender.female : AppValue.empty
@@ -235,8 +236,7 @@ extension InputPatientPresenter {
     
     @MainActor
     func addNewPatient() async -> Bool {
-        Logger.debug("Adding new patient - ID: \(patient._id)", category: .taskAssignment)
-        Logger.debug("Patient details: \(patient.name), NIK: \(patient.NIK), BPJS: \(patient.BPJS ?? "None")", category: .taskAssignment)
+        Logger.debug("Adding new patient", category: .taskAssignment)
 
         do {
             patient.name = selectedPatient
@@ -287,7 +287,7 @@ extension InputPatientPresenter {
         Task {
             await getPatientById(patientId: selectedPatient)
             await getUserById(userId: selectedPIC)
-            Logger.info("Examination data loaded for patient: \(patient.name)", category: .taskAssignment)
+            Logger.info("Examination data loaded", category: .taskAssignment)
         }
     }
 }
@@ -296,8 +296,14 @@ extension InputPatientPresenter {
 extension InputPatientPresenter {
     @MainActor
     func submitExamination() async {
+        guard !isSubmittingExamination else { return }
+        isSubmittingExamination = true
+        defer { isSubmittingExamination = false }
+
         guard let DPJPId = UserDefaults.standard.string(forKey: UserDefaultType.userId.rawValue) else {
+            errorMessage = AppTextTaskAssignInputExam.errorMessageFailedToGetResponse
             isError = true
+            Logger.error("Submit failed: missing DPJP user id in UserDefaults", category: .taskAssignment)
             return
         }
         
@@ -460,7 +466,7 @@ extension InputPatientPresenter {
             allowFuture: false,
             allowPast: true
         )
-        Logger.debug("Patient DoB updated to: \(selectedDoB)", category: .taskAssignment)
+        Logger.debug("Patient DoB updated", category: .taskAssignment)
     }
     
     func handleGenderChange() {
@@ -474,7 +480,7 @@ extension InputPatientPresenter {
         }
         // Validate Gender in real-time
         _ = validationManager.validateRequired(selectedSex, fieldName: ValidationFieldName.patientGender.fieldName)
-        Logger.debug("Patient gender updated to: \(patient.sex)", category: .taskAssignment)
+        Logger.debug("Patient gender updated", category: .taskAssignment)
     }
     
     func handleBPJSNumberChange() {
@@ -493,23 +499,23 @@ extension InputPatientPresenter {
         } else {
             validationManager.clearError(for: ValidationFieldName.patientBPJS.fieldName)
         }
-        Logger.debug("Patient BPJS updated to: \(BPJSnumber)", category: .taskAssignment)
+        Logger.debug("Patient BPJS updated", category: .taskAssignment)
     }
     
     func handleNIKChange() {
         // NIK validation is already handled by ValidatedTextField
         // Just trigger validation update for button state
-        Logger.debug("Patient NIK updated to: \(patient.NIK)", category: .taskAssignment)
+        Logger.debug("Patient NIK updated", category: .taskAssignment)
     }
     
     func handlePICChange() {
         _ = validationManager.validateRequired(selectedPIC, fieldName: ValidationFieldName.userRole.fieldName)
-        Logger.debug("PIC updated to: \(selectedPIC)", category: .taskAssignment)
+        Logger.debug("PIC selection updated", category: .taskAssignment)
     }
     
     func handlePatientSelectionChange() {
         _ = validationManager.validateRequired(selectedPatient, fieldName: ValidationFieldName.patientName.fieldName)
-        Logger.debug("Patient selection updated to: \(selectedPatient)", category: .taskAssignment)
+        Logger.debug("Patient selection updated", category: .taskAssignment)
     }
 }
 

--- a/Oculab/Modules/TaskAssignment/View/InputExaminationData.swift
+++ b/Oculab/Modules/TaskAssignment/View/InputExaminationData.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct InputExaminationData: View {
-    @ObservedObject var presenter: InputPatientPresenter = .init()
+    @StateObject var presenter: InputPatientPresenter = .init()
     @State var selectedPIC: String
-    @State var selectedPatient: String 
+    @State var selectedPatient: String
+    @State private var submitTask: Task<Void, Never>?
 
     var body: some View {
         NavigationView {
@@ -26,9 +27,10 @@ struct InputExaminationData: View {
                             title: AppTextTaskAssignInputExam.createTaskButton,
                             colorType: .primary,
                             size: .large,
-                            isEnabled: true
+                            isEnabled: !presenter.isSubmittingExamination
                         ) {
-                            Task {
+                            submitTask?.cancel()
+                            submitTask = Task {
                                 await presenter.submitExamination()
                             }
                         },
@@ -160,6 +162,9 @@ struct InputExaminationData: View {
             }
             .onAppear {
                 presenter.setupExaminationData(selectedPIC: selectedPIC, selectedPatient: selectedPatient)
+            }
+            .onDisappear {
+                submitTask?.cancel()
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/Oculab/Modules/TaskAssignment/View/InputPatientData.swift
+++ b/Oculab/Modules/TaskAssignment/View/InputPatientData.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 struct InputPatientData: View {
     let patientId: String?
-    @ObservedObject var presenter = InputPatientPresenter()
+    @StateObject var presenter = InputPatientPresenter()
     @EnvironmentObject private var authentication: AuthenticationPresenter
-    
+    @State private var loadTask: Task<Void, Never>?
+    @State private var patientChangeTask: Task<Void, Never>?
+    @State private var picChangeTask: Task<Void, Never>?
+
     init(patientId: String? = nil) {
         self.patientId = patientId
     }
@@ -88,15 +91,16 @@ struct InputPatientData: View {
                 }
             }
             .onAppear {
-                Task {
+                loadTask?.cancel()
+                loadTask = Task {
                     await presenter.getAllUser()
                     await presenter.getAllPatient()
-                    
+
                     // Auto-fill PIC for B2C LAB users
                     if authentication.user.role == .LAB && authentication.user.businessModel == .B2C {
                         presenter.selectedPIC = authentication.user._id
                     }
-                    
+
                     // Auto-fill patient if patientId is provided
                     if let patientId = patientId, !patientId.isEmpty {
                         await presenter.getPatientById(patientId: patientId)
@@ -105,10 +109,16 @@ struct InputPatientData: View {
                     }
                 }
             }
+            .onDisappear {
+                loadTask?.cancel()
+                patientChangeTask?.cancel()
+                picChangeTask?.cancel()
+            }
             .dismissKeyboardOnTap()
             .onChange(of: presenter.selectedPatient) { _, newValue in
-                Task {
-                    Logger.info("Selected patient changed: \(presenter.selectedPatient)", category: .taskAssignment)
+                patientChangeTask?.cancel()
+                patientChangeTask = Task {
+                    Logger.info("Selected patient changed", category: .taskAssignment)
                     // Only fetch if it's not already auto-filled
                     if patientId == nil || newValue != patientId {
                         await presenter.getPatientById(patientId: newValue)
@@ -117,7 +127,8 @@ struct InputPatientData: View {
             }
             .onChange(of: presenter.selectedPIC) { _, newValue in
                 if !newValue.isEmpty {
-                    Task {
+                    picChangeTask?.cancel()
+                    picChangeTask = Task {
                         await presenter.getUserById(userId: newValue)
                     }
                 }


### PR DESCRIPTION
## Summary
- **PII log scrub** — `InputPatientPresenter` was logging patient name, NIK, BPJS, DoB, and sex via `Logger.debug/.info`. Replaced with non-PII messages so OS-level log capture (Console, sysdiagnose) no longer carries patient identifiers.
- **Silent submit guard** — `submitExamination()` returned with `isError = true` but no `errorMessage` when the DPJP user id was missing from `UserDefaults`. Users saw a blank alert. Now sets a localized message and logs the cause.
- **Double-submit guard** — confirm button on the create-task popup was `isEnabled: true` and the bare `Task { await ... }` ignored re-taps. Added `isSubmittingExamination` flag, disabled the button while in flight, and made the view-side task cancellable.
- **Presenter ownership** — `InputPatientData` and `InputExaminationData` used `@ObservedObject` for a presenter created with `= InputPatientPresenter()`. SwiftUI does not own those, so a parent redraw could recreate them mid-flow. Switched to `@StateObject`.
- **Task leaks** — `onAppear`/`onChange` fired Tasks without handles. Added cancellable `Task<Void, Never>?` state for load, patient-change, PIC-change, and submit, and cancel them on `onDisappear`.

## Out of scope (deferred)
- Authorization gap on `Router.canNavigateToRoute()` — same architectural concern deferred in #190; needs a real role-gating story, not a mechanical patch.
- Magic numbers (`UIScreen.main.bounds.width / 3.5`, paddings in `DateField`/`PatientDisplayField`) — the `Decimal` enum doesn't carry these constants today; adding new ones touches the broader design system.
- The didSet validation pattern in the presenter — already lightweight, not a clear win to remove.

## Test plan
- [ ] Open Input Patient screen → select PIC and patient → fill required fields → tap Fill Specimen Details. No regression in flow.
- [ ] On Input Examination screen, tap Create Task in the confirm popup. Confirm button disables until network call resolves; rapid taps cannot double-submit.
- [ ] Force-clear `UserDefaults` user id and submit. Alert shows a real message instead of empty body.
- [ ] Sysdiagnose / Console.app log capture during a patient flow contains no name/NIK/BPJS/DoB/sex strings.
- [ ] Navigate away from Input Patient mid-load → no crash, no late state update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)